### PR TITLE
Add structured APIError with upgrade_url field

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -3,6 +3,7 @@
  */
 
 import { Sprite } from './sprite.js';
+import { parseAPIError } from './types.js';
 import type {
   ClientOptions,
   SpriteConfig,
@@ -53,6 +54,9 @@ export class SpritesClient {
 
     if (!response.ok) {
       const body = await response.text();
+      const headers = Object.fromEntries(response.headers.entries());
+      const apiErr = parseAPIError(response.status, body, headers);
+      if (apiErr) throw apiErr;
       throw new Error(`Failed to create sprite (status ${response.status}): ${body}`);
     }
 
@@ -72,12 +76,11 @@ export class SpritesClient {
       signal: AbortSignal.timeout(this.timeout),
     });
 
-    if (response.status === 404) {
-      throw new Error(`Sprite not found: ${name}`);
-    }
-
     if (!response.ok) {
       const body = await response.text();
+      const headers = Object.fromEntries(response.headers.entries());
+      const apiErr = parseAPIError(response.status, body, headers);
+      if (apiErr) throw apiErr;
       throw new Error(`Failed to get sprite (status ${response.status}): ${body}`);
     }
 
@@ -107,6 +110,9 @@ export class SpritesClient {
 
     if (!response.ok) {
       const body = await response.text();
+      const headers = Object.fromEntries(response.headers.entries());
+      const apiErr = parseAPIError(response.status, body, headers);
+      if (apiErr) throw apiErr;
       throw new Error(`Failed to list sprites (status ${response.status}): ${body}`);
     }
 
@@ -153,6 +159,9 @@ export class SpritesClient {
 
     if (!response.ok && response.status !== 204) {
       const body = await response.text();
+      const headers = Object.fromEntries(response.headers.entries());
+      const apiErr = parseAPIError(response.status, body, headers);
+      if (apiErr) throw apiErr;
       throw new Error(`Failed to delete sprite (status ${response.status}): ${body}`);
     }
   }
@@ -171,6 +180,9 @@ export class SpritesClient {
 
     if (!response.ok && response.status !== 204) {
       const body = await response.text();
+      const headers = Object.fromEntries(response.headers.entries());
+      const apiErr = parseAPIError(response.status, body, headers);
+      if (apiErr) throw apiErr;
       throw new Error(`Failed to upgrade sprite (status ${response.status}): ${body}`);
     }
   }
@@ -193,6 +205,9 @@ export class SpritesClient {
 
     if (!response.ok) {
       const body = await response.text();
+      const headers = Object.fromEntries(response.headers.entries());
+      const apiErr = parseAPIError(response.status, body, headers);
+      if (apiErr) throw apiErr;
       throw new Error(`Failed to update URL settings (status ${response.status}): ${body}`);
     }
   }
@@ -228,6 +243,9 @@ export class SpritesClient {
 
     if (!response.ok) {
       const text = await response.text();
+      const headers = Object.fromEntries(response.headers.entries());
+      const apiErr = parseAPIError(response.status, text, headers);
+      if (apiErr) throw apiErr;
       throw new Error(`API returned status ${response.status}: ${text}`);
     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -50,5 +50,13 @@ export type {
   ChmodOptions,
 } from './types.js';
 
-export { ExecError, StreamID, FilesystemError } from './types.js';
+export {
+  ExecError,
+  StreamID,
+  FilesystemError,
+  APIError,
+  parseAPIError,
+  ERR_CODE_CREATION_RATE_LIMITED,
+  ERR_CODE_CONCURRENT_LIMIT_EXCEEDED,
+} from './types.js';
 

--- a/src/websocket.ts
+++ b/src/websocket.ts
@@ -1,5 +1,9 @@
 /**
  * WebSocket communication layer for command execution
+ *
+ * Note: The standard WebSocket API does not expose HTTP error responses
+ * on connection failure. For structured APIError handling, see the HTTP
+ * client methods in client.ts which use parseAPIError.
  */
 
 import { EventEmitter } from 'node:events';


### PR DESCRIPTION
## Summary

- Add `APIError` class with all structured fields including `upgradeUrl`
- Add `parseAPIError()` function for parsing HTTP error responses
- Update `client.ts` to use `parseAPIError` for all HTTP error handling
- Add comprehensive tests for `APIError` and `parseAPIError`
- Export `APIError` and related utilities from `index.ts`

This matches the error handling improvements in the Go SDK, allowing callers to access structured error information (error code, limits, upgrade URL) directly from rate limit and other API errors.