### PR TITLE
Fix control mode: default to off and add fallback

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -22,11 +22,13 @@ export class SpritesClient {
   readonly baseURL: string;
   readonly token: string;
   private readonly timeout: number;
+  readonly controlMode: boolean;
 
   constructor(token: string, options: ClientOptions = {}) {
     this.token = token;
     this.baseURL = (options.baseURL || 'https://api.sprites.dev').replace(/\/+$/, '');
     this.timeout = options.timeout || 30000;
+    this.controlMode = options.controlMode === true;
   }
 
   /**

--- a/src/control.test.ts
+++ b/src/control.test.ts
@@ -1,0 +1,76 @@
+/**
+ * Unit tests for the control connection module
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import { SpritesClient } from './client.js';
+
+describe('Control Mode Client Options', () => {
+  it('should have controlMode false by default', () => {
+    const client = new SpritesClient('test-token');
+    assert.strictEqual(client.controlMode, false);
+  });
+
+  it('should enable controlMode when explicitly specified', () => {
+    const client = new SpritesClient('test-token', { controlMode: true });
+    assert.strictEqual(client.controlMode, true);
+  });
+
+  it('should disable controlMode when explicitly set to false', () => {
+    const client = new SpritesClient('test-token', { controlMode: false });
+    assert.strictEqual(client.controlMode, false);
+  });
+});
+
+describe('Sprite Control Mode', () => {
+  it('should reflect client controlMode setting when enabled', () => {
+    const client = new SpritesClient('test-token', { controlMode: true });
+    const sprite = client.sprite('test-sprite');
+    assert.strictEqual(sprite.useControlMode(), true);
+  });
+
+  it('should reflect client controlMode setting when disabled', () => {
+    const client = new SpritesClient('test-token', { controlMode: false });
+    const sprite = client.sprite('test-sprite');
+    assert.strictEqual(sprite.useControlMode(), false);
+  });
+
+  it('should return false when controlMode is not specified (disabled by default)', () => {
+    const client = new SpritesClient('test-token');
+    const sprite = client.sprite('test-sprite');
+    assert.strictEqual(sprite.useControlMode(), false);
+  });
+});
+
+describe('Control URL Building', () => {
+  it('should build correct control endpoint URL', () => {
+    const client = new SpritesClient('test-token', { baseURL: 'http://localhost:8080' });
+    const sprite = client.sprite('my-sprite');
+
+    // Build expected URL
+    const expectedURL = 'ws://localhost:8080/v1/sprites/my-sprite/control';
+
+    // Build actual URL (simulating what ControlConnection does)
+    let baseURL = sprite.client.baseURL;
+    if (baseURL.startsWith('http')) {
+      baseURL = 'ws' + baseURL.substring(4);
+    }
+    const actualURL = `${baseURL}/v1/sprites/${sprite.name}/control`;
+
+    assert.strictEqual(actualURL, expectedURL);
+  });
+
+  it('should convert HTTPS to WSS for control endpoint', () => {
+    const client = new SpritesClient('test-token', { baseURL: 'https://api.sprites.dev' });
+    const sprite = client.sprite('my-sprite');
+
+    let baseURL = sprite.client.baseURL;
+    if (baseURL.startsWith('http')) {
+      baseURL = 'ws' + baseURL.substring(4);
+    }
+    const actualURL = `${baseURL}/v1/sprites/${sprite.name}/control`;
+
+    assert.ok(actualURL.startsWith('wss://'));
+  });
+});

--- a/src/control.ts
+++ b/src/control.ts
@@ -1,0 +1,605 @@
+/**
+ * Control connection for multiplexed operations over a single WebSocket.
+ */
+
+import { EventEmitter } from 'node:events';
+import type { Sprite } from './sprite.js';
+import { StreamID } from './types.js';
+
+// Control envelope protocol constants (must match server's pkg/wss).
+const CONTROL_PREFIX = 'control:';
+const TYPE_OP_START = 'op.start';
+const TYPE_OP_COMPLETE = 'op.complete';
+const TYPE_OP_ERROR = 'op.error';
+
+/**
+ * Control message envelope
+ */
+interface ControlMessage {
+  type: string;
+  op?: string;
+  args?: Record<string, unknown>;
+}
+
+/**
+ * Options for starting an operation
+ */
+export interface StartOpOptions {
+  /** Command arguments */
+  cmd?: string[];
+  /** Environment variables */
+  env?: string[];
+  /** Working directory */
+  dir?: string;
+  /** Enable TTY mode */
+  tty?: boolean;
+  /** TTY rows */
+  rows?: number;
+  /** TTY columns */
+  cols?: number;
+  /** Whether stdin is expected */
+  stdin?: boolean;
+}
+
+/**
+ * OpConn represents an active operation on a control connection.
+ * It provides methods for reading/writing data frames during the operation.
+ */
+export class OpConn extends EventEmitter {
+  private closed: boolean = false;
+  private exitCode: number = -1;
+
+  constructor(
+    private cc: ControlConnection,
+    private tty: boolean
+  ) {
+    super();
+  }
+
+  /**
+   * Write data to the operation (stdin)
+   */
+  write(data: Buffer): void {
+    if (this.closed) {
+      throw new Error('Operation closed');
+    }
+
+    if (this.tty) {
+      // PTY mode - send raw data
+      this.cc.sendData(data);
+    } else {
+      // Non-PTY mode - prepend stream ID
+      const message = Buffer.allocUnsafe(data.length + 1);
+      message[0] = StreamID.Stdin;
+      data.copy(message, 1);
+      this.cc.sendData(message);
+    }
+  }
+
+  /**
+   * Send stdin EOF
+   */
+  sendEOF(): void {
+    if (this.closed || this.tty) return;
+    this.cc.sendData(Buffer.from([StreamID.StdinEOF]));
+  }
+
+  /**
+   * Send resize control message (TTY only)
+   */
+  resize(cols: number, rows: number): void {
+    if (!this.tty) return;
+    const msg = JSON.stringify({ type: 'resize', cols, rows });
+    this.cc.sendData(Buffer.from(msg));
+  }
+
+  /**
+   * Send signal to remote process
+   */
+  signal(sig: string): void {
+    const msg = JSON.stringify({ type: 'signal', signal: sig });
+    this.cc.sendData(Buffer.from(msg));
+  }
+
+  /**
+   * Handle incoming data frame
+   */
+  handleData(data: Buffer): void {
+    if (this.tty) {
+      // PTY mode - emit raw output
+      this.emit('stdout', data);
+    } else {
+      // Non-PTY mode - parse stream prefix
+      if (data.length === 0) return;
+
+      const streamId = data[0] as StreamID;
+      const payload = data.subarray(1);
+
+      switch (streamId) {
+        case StreamID.Stdout:
+          this.emit('stdout', payload);
+          break;
+        case StreamID.Stderr:
+          this.emit('stderr', payload);
+          break;
+        case StreamID.Exit:
+          // Store exit code but DON'T close yet
+          // Wait for op.complete message to ensure proper sequencing
+          this.exitCode = payload.length > 0 ? payload[0] : 0;
+          this.emit('exit', this.exitCode);
+          break;
+      }
+    }
+  }
+
+  /**
+   * Handle text message (session_info, notifications, etc.)
+   */
+  handleText(data: string): void {
+    try {
+      const msg = JSON.parse(data);
+      this.emit('message', msg);
+    } catch {
+      // Not JSON, ignore
+    }
+  }
+
+  /**
+   * Mark operation as complete
+   */
+  complete(exitCode?: number): void {
+    if (this.closed) return;
+    this.closed = true;
+    if (exitCode !== undefined) {
+      this.exitCode = exitCode;
+    }
+    this.emit('close');
+  }
+
+  /**
+   * Close the operation
+   */
+  close(): void {
+    if (this.closed) return;
+    this.closed = true;
+    this.emit('close');
+  }
+
+  /**
+   * Whether the operation is closed
+   */
+  isClosed(): boolean {
+    return this.closed;
+  }
+
+  /**
+   * Get exit code (-1 if not exited)
+   */
+  getExitCode(): number {
+    return this.exitCode;
+  }
+
+  /**
+   * Wait for operation to complete
+   */
+  async wait(): Promise<number> {
+    if (this.closed) {
+      return this.exitCode;
+    }
+
+    return new Promise((resolve) => {
+      this.once('close', () => {
+        resolve(this.exitCode);
+      });
+    });
+  }
+}
+
+/**
+ * ControlConnection manages a persistent WebSocket connection for multiplexed operations.
+ */
+export class ControlConnection extends EventEmitter {
+  private ws: WebSocket | null = null;
+  private opActive: boolean = false;
+  private opConn: OpConn | null = null;
+  private closed: boolean = false;
+  private closeError: Error | null = null;
+  private poolActive: boolean = false; // Tracks if connection is in use by pool
+
+  constructor(
+    private sprite: Sprite
+  ) {
+    super();
+  }
+
+  /**
+   * Check if this connection is marked as active (in use) by the pool
+   */
+  isActive(): boolean {
+    return this.poolActive;
+  }
+
+  /**
+   * Set the pool active state
+   */
+  setActive(active: boolean): void {
+    this.poolActive = active;
+  }
+
+  /**
+   * Clear the operation connection (called by pool on release)
+   */
+  clearOpConn(): void {
+    this.opConn = null;
+  }
+
+  /**
+   * Connect to the control endpoint
+   */
+  async connect(): Promise<void> {
+    if (this.ws) {
+      throw new Error('Already connected');
+    }
+
+    // Build WebSocket URL
+    let baseURL = this.sprite.client.baseURL;
+    if (baseURL.startsWith('http')) {
+      baseURL = 'ws' + baseURL.substring(4);
+    }
+
+    const url = `${baseURL}/v1/sprites/${this.sprite.name}/control`;
+
+    return new Promise((resolve, reject) => {
+      try {
+        this.ws = new WebSocket(url, {
+          headers: {
+            'Authorization': `Bearer ${this.sprite.client.token}`,
+          },
+        });
+
+        this.ws.binaryType = 'arraybuffer';
+
+        this.ws.addEventListener('open', () => {
+          resolve();
+        });
+
+        this.ws.addEventListener('error', () => {
+          const error = new Error('WebSocket error');
+          this.closeError = error;
+          this.emit('error', error);
+          if (!this.ws || this.ws.readyState !== WebSocket.OPEN) {
+            reject(error);
+          }
+        });
+
+        this.ws.addEventListener('message', (event) => {
+          this.handleMessage(event);
+        });
+
+        this.ws.addEventListener('close', () => {
+          this.handleClose();
+        });
+      } catch (error) {
+        reject(error);
+      }
+    });
+  }
+
+  /**
+   * Handle incoming WebSocket message
+   */
+  private handleMessage(event: MessageEvent): void {
+    // Check for control message
+    if (typeof event.data === 'string' && event.data.startsWith(CONTROL_PREFIX)) {
+      const payload = event.data.substring(CONTROL_PREFIX.length);
+      try {
+        const msg = JSON.parse(payload) as ControlMessage;
+        this.handleControlMessage(msg);
+      } catch {
+        // Malformed control message, ignore
+      }
+      return;
+    }
+
+    // Data frame - deliver to active operation
+    if (this.opConn) {
+      if (typeof event.data === 'string') {
+        this.opConn.handleText(event.data);
+      } else {
+        this.opConn.handleData(Buffer.from(event.data as ArrayBuffer));
+      }
+    }
+  }
+
+  /**
+   * Handle control envelope message
+   */
+  private handleControlMessage(msg: ControlMessage): void {
+    switch (msg.type) {
+      case TYPE_OP_COMPLETE:
+        if (this.opConn) {
+          const exitCode = (msg.args?.exitCode as number) ?? 0;
+          this.opConn.complete(exitCode);
+        }
+        this.opActive = false;
+        this.opConn = null;
+        break;
+
+      case TYPE_OP_ERROR:
+        if (this.opConn) {
+          const error = (msg.args?.error as string) ?? 'unknown error';
+          this.opConn.emit('error', new Error(error));
+          this.opConn.complete();
+        }
+        this.opActive = false;
+        this.opConn = null;
+        break;
+    }
+  }
+
+  /**
+   * Handle WebSocket close
+   */
+  private handleClose(): void {
+    this.closed = true;
+    if (this.opConn) {
+      this.opConn.close();
+    }
+    this.emit('close');
+  }
+
+  /**
+   * Start a new operation
+   */
+  async startOp(op: string, options: StartOpOptions = {}): Promise<OpConn> {
+    if (this.closed) {
+      throw new Error(`Control connection closed: ${this.closeError?.message || 'unknown'}`);
+    }
+
+    if (this.opActive) {
+      throw new Error('Operation already in progress');
+    }
+
+    if (!this.ws || this.ws.readyState !== WebSocket.OPEN) {
+      throw new Error('WebSocket not connected');
+    }
+
+    this.opActive = true;
+    const opConn = new OpConn(this, options.tty || false);
+    this.opConn = opConn;
+
+    // Build args for the control message
+    const args: Record<string, unknown> = {};
+    if (options.cmd) args.cmd = options.cmd;
+    if (options.env) args.env = options.env;
+    if (options.dir) args.dir = options.dir;
+    if (options.tty) args.tty = 'true';
+    if (options.rows) args.rows = options.rows.toString();
+    if (options.cols) args.cols = options.cols.toString();
+    if (options.stdin !== undefined) args.stdin = options.stdin ? 'true' : 'false';
+
+    // Send op.start
+    const ctrlMsg: ControlMessage = {
+      type: TYPE_OP_START,
+      op,
+      args,
+    };
+    this.sendControl(ctrlMsg);
+
+    return opConn;
+  }
+
+  /**
+   * Send control envelope
+   */
+  private sendControl(msg: ControlMessage): void {
+    if (!this.ws || this.ws.readyState !== WebSocket.OPEN) {
+      throw new Error('WebSocket not connected');
+    }
+    const frame = CONTROL_PREFIX + JSON.stringify(msg);
+    this.ws.send(frame);
+  }
+
+  /**
+   * Send data frame
+   */
+  sendData(data: Buffer): void {
+    if (!this.ws || this.ws.readyState !== WebSocket.OPEN) {
+      throw new Error('WebSocket not connected');
+    }
+    this.ws.send(data);
+  }
+
+  /**
+   * Close the control connection
+   */
+  close(): void {
+    if (this.opConn) {
+      this.opConn.close();
+    }
+    if (this.ws && this.ws.readyState === WebSocket.OPEN) {
+      this.ws.close(1000, '');
+    }
+    this.closed = true;
+  }
+
+  /**
+   * Whether the connection is closed
+   */
+  isClosed(): boolean {
+    return this.closed;
+  }
+}
+
+// Pool configuration (matches Go SDK)
+const MAX_POOL_SIZE = 100; // Sanity cap - checkout fails if pool is full
+const POOL_DRAIN_THRESHOLD = 20; // When release and size > this, drain idle conns
+const POOL_DRAIN_TARGET = 10; // Drain down to this many conns when draining
+
+/**
+ * ControlPool manages a pool of control connections for concurrent operations.
+ */
+export class ControlPool {
+  private conns: ControlConnection[] = [];
+  private waiters: Array<{
+    resolve: (cc: ControlConnection) => void;
+    reject: (err: Error) => void;
+  }> = [];
+  private closed: boolean = false;
+
+  constructor(
+    private sprite: Sprite,
+    private maxSize: number = MAX_POOL_SIZE
+  ) {}
+
+  /**
+   * Acquire a connection from the pool.
+   * Creates a new connection if the pool isn't full, otherwise waits.
+   */
+  async acquire(): Promise<ControlConnection> {
+    if (this.closed) {
+      throw new Error('Pool is closed');
+    }
+
+    // Try to find an available connection
+    for (const cc of this.conns) {
+      if (!cc.isClosed() && !cc.isActive()) {
+        cc.setActive(true);
+        return cc;
+      }
+    }
+
+    // If pool isn't full, create a new connection
+    if (this.conns.length < this.maxSize) {
+      const cc = new ControlConnection(this.sprite);
+      await cc.connect();
+      this.conns.push(cc);
+      cc.setActive(true);
+      return cc;
+    }
+
+    // Pool is full, wait for a connection
+    return new Promise((resolve, reject) => {
+      this.waiters.push({ resolve, reject });
+    });
+  }
+
+  /**
+   * Release a connection back to the pool.
+   */
+  release(cc: ControlConnection): void {
+    cc.setActive(false);
+    cc.clearOpConn();
+
+    // If there are waiters, give them this connection
+    if (this.waiters.length > 0) {
+      const waiter = this.waiters.shift()!;
+      cc.setActive(true);
+      waiter.resolve(cc);
+      return;
+    }
+
+    // Try to drain idle connections if pool is large
+    this.tryDrain();
+  }
+
+  /**
+   * Drain idle connections when pool is large.
+   * When pool size exceeds POOL_DRAIN_THRESHOLD, close idle connections
+   * down to POOL_DRAIN_TARGET.
+   */
+  private tryDrain(): void {
+    if (this.closed || this.conns.length <= POOL_DRAIN_THRESHOLD) {
+      return;
+    }
+
+    // Find idle connections (not active, not closed)
+    const idleConns = this.conns.filter(
+      (cc) => !cc.isActive() && !cc.isClosed()
+    );
+
+    const toClose = this.conns.length - POOL_DRAIN_TARGET;
+    if (toClose <= 0) {
+      return;
+    }
+
+    // Close idle connections
+    let closed = 0;
+    for (const cc of idleConns) {
+      if (closed >= toClose) break;
+      cc.close();
+      this.conns = this.conns.filter((c) => c !== cc);
+      closed++;
+    }
+  }
+
+  /**
+   * Close all connections in the pool.
+   */
+  close(): void {
+    this.closed = true;
+
+    // Cancel all waiters
+    for (const waiter of this.waiters) {
+      waiter.reject(new Error('Pool is closed'));
+    }
+    this.waiters = [];
+
+    // Close all connections
+    for (const cc of this.conns) {
+      cc.close();
+    }
+    this.conns = [];
+  }
+
+  /**
+   * Get the current number of connections in the pool.
+   */
+  size(): number {
+    return this.conns.length;
+  }
+
+  /**
+   * Check if the pool has any active connections.
+   */
+  hasConnections(): boolean {
+    return this.conns.length > 0;
+  }
+}
+
+/**
+ * Get or create a control pool for a sprite.
+ */
+const controlPools = new WeakMap<Sprite, ControlPool>();
+
+export async function getControlConnection(sprite: Sprite): Promise<ControlConnection> {
+  let pool = controlPools.get(sprite);
+
+  // Get or create pool
+  if (!pool) {
+    pool = new ControlPool(sprite);
+    controlPools.set(sprite, pool);
+  }
+
+  return pool.acquire();
+}
+
+export function releaseControlConnection(sprite: Sprite, cc: ControlConnection): void {
+  const pool = controlPools.get(sprite);
+  if (pool) {
+    pool.release(cc);
+  }
+}
+
+export function closeControlConnection(sprite: Sprite): void {
+  const pool = controlPools.get(sprite);
+  if (pool) {
+    pool.close();
+    controlPools.delete(sprite);
+  }
+}
+
+export function hasControlConnection(sprite: Sprite): boolean {
+  const pool = controlPools.get(sprite);
+  return pool !== undefined && pool.hasConnections();
+}

--- a/src/control.ts
+++ b/src/control.ts
@@ -259,15 +259,21 @@ export class ControlConnection extends EventEmitter {
 
         this.ws.binaryType = 'arraybuffer';
 
+        let connected = false;
+
         this.ws.addEventListener('open', () => {
+          connected = true;
           resolve();
         });
 
         this.ws.addEventListener('error', () => {
           const error = new Error('WebSocket error');
           this.closeError = error;
-          this.emit('error', error);
-          if (!this.ws || this.ws.readyState !== WebSocket.OPEN) {
+          if (connected) {
+            // Post-connection error: emit on EventEmitter for listeners
+            this.emit('error', error);
+          } else {
+            // Pre-connection error: reject the connect() promise
             reject(error);
           }
         });

--- a/src/exec.ts
+++ b/src/exec.ts
@@ -273,6 +273,15 @@ export async function execFile(
   args: string[] = [],
   options: ExecOptions = {}
 ): Promise<ExecResult> {
+  // Use control mode if enabled and not attaching to a session
+  if (!options.sessionId && sprite.useControlMode()) {
+    try {
+      return await execFileViaControl(sprite, file, args, options);
+    } catch {
+      // Control connection failed (server may not support it), fall back to regular WebSocket
+    }
+  }
+
   const encoding = options.encoding || 'utf8';
   const maxBuffer = options.maxBuffer || 10 * 1024 * 1024; // 10MB default
 
@@ -326,5 +335,92 @@ export async function execFile(
 
     cmd.start().catch(reject);
   });
+}
+
+/**
+ * Execute a file via control connection for multiplexed operations
+ */
+async function execFileViaControl(
+  sprite: Sprite,
+  file: string,
+  args: string[] = [],
+  options: ExecOptions = {}
+): Promise<ExecResult> {
+  const { releaseControlConnection } = await import('./control.js');
+  const encoding = options.encoding || 'utf8';
+  const maxBuffer = options.maxBuffer || 10 * 1024 * 1024; // 10MB default
+
+  // Get a control connection from the pool
+  const cc = await sprite.getControlConnection();
+
+  // Build operation options
+  const opOptions = {
+    cmd: [file, ...args],
+    env: options.env ? Object.entries(options.env).map(([k, v]) => `${k}=${v}`) : undefined,
+    dir: options.cwd,
+    tty: options.tty,
+    rows: options.rows,
+    cols: options.cols,
+    stdin: true, // Enable stdin by default
+  };
+
+  try {
+    // Start the operation
+    const op = await cc.startOp('exec', opOptions);
+
+    return await new Promise((resolve, reject) => {
+      const stdoutChunks: Buffer[] = [];
+      const stderrChunks: Buffer[] = [];
+      let stdoutLength = 0;
+      let stderrLength = 0;
+
+      op.on('stdout', (data: Buffer) => {
+        stdoutChunks.push(data);
+        stdoutLength += data.length;
+        if (stdoutLength > maxBuffer) {
+          op.signal('KILL');
+          reject(new Error(`stdout maxBuffer exceeded`));
+        }
+      });
+
+      op.on('stderr', (data: Buffer) => {
+        stderrChunks.push(data);
+        stderrLength += data.length;
+        if (stderrLength > maxBuffer) {
+          op.signal('KILL');
+          reject(new Error(`stderr maxBuffer exceeded`));
+        }
+      });
+
+      op.on('error', (error: Error) => {
+        reject(error);
+      });
+
+      // Send stdin EOF since we're not providing input
+      op.sendEOF();
+
+      // Wait for completion
+      op.wait().then((code) => {
+        const stdoutBuffer = Buffer.concat(stdoutChunks);
+        const stderrBuffer = Buffer.concat(stderrChunks);
+
+        const result: ExecResult = {
+          stdout: encoding === ('buffer' as any) ? stdoutBuffer : stdoutBuffer.toString(encoding),
+          stderr: encoding === ('buffer' as any) ? stderrBuffer : stderrBuffer.toString(encoding),
+          exitCode: code,
+        };
+
+        if (code !== 0) {
+          const error = new ExecError(`Command failed with exit code ${code}`, result);
+          reject(error);
+        } else {
+          resolve(result);
+        }
+      }).catch(reject);
+    });
+  } finally {
+    // Always release the connection back to the pool
+    releaseControlConnection(sprite, cc);
+  }
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,8 @@ export { CheckpointStream, RestoreStream } from './checkpoint.js';
 export { ProxySession, ProxyManager, proxyPort, proxyPorts } from './proxy.js';
 export { ServiceLogStream } from './services.js';
 export { SpriteFilesystem } from './filesystem.js';
+export { ControlConnection, OpConn } from './control.js';
+export type { StartOpOptions } from './control.js';
 
 export type {
   ClientOptions,

--- a/src/sprite.ts
+++ b/src/sprite.ts
@@ -18,6 +18,7 @@ import {
 } from './services.js';
 import { getNetworkPolicy, updateNetworkPolicy } from './policy.js';
 import { SpriteFilesystem } from './filesystem.js';
+import { ControlConnection, getControlConnection, closeControlConnection, hasControlConnection } from './control.js';
 import type {
   SpawnOptions,
   ExecOptions,
@@ -405,6 +406,36 @@ export class Sprite {
    */
   filesystem(workingDir: string = '/'): SpriteFilesystem {
     return new SpriteFilesystem(this.client, this.name, workingDir);
+  }
+
+  // ========== Control Connection API ==========
+
+  /**
+   * Check if control mode is enabled for this sprite
+   */
+  useControlMode(): boolean {
+    return this.client.controlMode;
+  }
+
+  /**
+   * Get or create a control connection for multiplexed operations
+   */
+  async getControlConnection(): Promise<ControlConnection> {
+    return getControlConnection(this);
+  }
+
+  /**
+   * Close the control connection if open
+   */
+  closeControlConnection(): void {
+    closeControlConnection(this);
+  }
+
+  /**
+   * Check if this sprite has an active control connection.
+   */
+  hasControlConnection(): boolean {
+    return hasControlConnection(this);
   }
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,6 +10,8 @@ export interface ClientOptions {
   baseURL?: string;
   /** HTTP request timeout in milliseconds (default: 30000) */
   timeout?: number;
+  /** Enable control mode for multiplexed WebSocket operations */
+  controlMode?: boolean;
 }
 
 /**


### PR DESCRIPTION
## Summary

- **Default `controlMode` to `false`** (opt-in) instead of `true` — servers that don't support the `/control` WebSocket endpoint no longer crash the SDK
- **Add graceful fallback** in `execFile` — if a control connection fails, transparently falls back to regular per-command WebSocket execution

## Context

Control mode was merged in #4 with `controlMode: true` as the default. This broke the `sprite-env` release pipeline because the example generator runs `exec()` against sprites that don't have control connection support. The WebSocket upgrade to `/v1/sprites/{name}/control` fails and the unhandled error crashes the process.

See: https://github.com/superfly/sprite-env/actions/runs/21733080553/job/62692018553

## Test plan

- [x] Unit tests pass (`npm run test:unit` — 25 tests)
- [x] Control tests pass (`node --test dist/control.test.ts` — 8 tests)
- [ ] After merging, update `sprite-env` submodule pointer for `sdks/js` and verify example generation succeeds