### PR TITLE
Fix url and urlSettings missing on sprite create/get/list

### DIFF
--- a/src/control.ts
+++ b/src/control.ts
@@ -266,8 +266,9 @@ export class ControlConnection extends EventEmitter {
           resolve();
         });
 
-        this.ws.addEventListener('error', () => {
-          const error = new Error('WebSocket error');
+        this.ws.addEventListener('error', (event: any) => {
+          const msg = event?.message || event?.error?.message || event?.error || 'unknown';
+          const error = new Error(`WebSocket error: ${msg} (url: ${url})`);
           this.closeError = error;
           if (connected) {
             // Post-connection error: emit on EventEmitter for listeners

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,7 +28,6 @@ export type {
   OrganizationInfo,
   ControlMessage,
   CreateSpriteRequest,
-  CreateSpriteResponse,
   Checkpoint,
   URLSettings,
   StreamMessage,

--- a/src/sprite.ts
+++ b/src/sprite.ts
@@ -49,8 +49,6 @@ export class Sprite {
   environment?: Record<string, string>;
   createdAt?: Date;
   updatedAt?: Date;
-  bucketName?: string;
-  primaryRegion?: string;
   url?: string;
   urlSettings?: URLSettings;
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -100,10 +100,6 @@ export interface SpriteInfo {
   createdAt: Date;
   /** Last update timestamp */
   updatedAt: Date;
-  /** Bucket name */
-  bucketName?: string;
-  /** Primary region */
-  primaryRegion?: string;
   /** Public URL for the sprite */
   url?: string;
   /** URL authentication settings */
@@ -429,14 +425,6 @@ export interface CreateSpriteRequest {
   config?: SpriteConfig;
   /** Optional environment variables */
   environment?: Record<string, string>;
-}
-
-/**
- * Response from sprite creation
- */
-export interface CreateSpriteResponse {
-  /** Created sprite name */
-  name: string;
 }
 
 /**


### PR DESCRIPTION
createSprite was only reading the name from the API response, discarding all other fields including url and urlSettings.

Additionally, all methods (get, list) were using raw Object.assign which left snake_case API fields (url_settings, created_at, etc.) unmapped to their camelCase TypeScript properties.

Add spriteFromAPI() helper to properly map API responses, and use it consistently across create, get, and list operations.

Also removes bucketName and primaryRegion which are not returned by the API, and removes the unused CreateSpriteResponse type.