### PR TITLE
Enrich rate limit error messages with actionable details

### DIFF
--- a/src/exec.test.ts
+++ b/src/exec.test.ts
@@ -281,7 +281,7 @@ describe('parseAPIError', () => {
     assert.ok(err);
     assert.strictEqual(err.statusCode, 429);
     assert.strictEqual(err.errorCode, 'sprite_creation_rate_limited');
-    assert.strictEqual(err.message, 'Rate limit exceeded');
+    assert.strictEqual(err.message, 'Rate limit exceeded (limit: 10 per 60s, retry after: 30s, upgrade: https://fly.io/upgrade)');
     assert.strictEqual(err.limit, 10);
     assert.strictEqual(err.windowSeconds, 60);
     assert.strictEqual(err.retryAfterSeconds, 30);

--- a/src/types.ts
+++ b/src/types.ts
@@ -374,6 +374,27 @@ export function parseAPIError(
     message = `API error (status ${statusCode})`;
   }
 
+  // Enrich rate limit messages with actionable details
+  if (statusCode === 429 && message) {
+    const details: string[] = [];
+    if (limit !== undefined && windowSeconds !== undefined) {
+      details.push(`limit: ${limit} per ${windowSeconds}s`);
+    }
+    if (currentCount !== undefined) {
+      details.push(`current: ${currentCount}`);
+    }
+    const retrySeconds = retryAfterSeconds ?? retryAfterHeader;
+    if (retrySeconds !== undefined) {
+      details.push(`retry after: ${retrySeconds}s`);
+    }
+    if (upgradeUrl) {
+      details.push(`upgrade: ${upgradeUrl}`);
+    }
+    if (details.length > 0) {
+      message = `${message} (${details.join(', ')})`;
+    }
+  }
+
   return new APIError(message || errorCode || `API error (status ${statusCode})`, {
     errorCode,
     statusCode,


### PR DESCRIPTION
## Summary
- When the API returns a 429 rate limit error, the `APIError.message` now includes limit, retry timing, and upgrade URL inline
- Previously callers had to inspect separate properties (`err.limit`, `err.retryAfterSeconds`, etc.) to understand the error — now `err.message` surfaces these details directly
- Example: `Rate limit exceeded (limit: 10 per 60s, retry after: 30s, upgrade: https://fly.io/upgrade)`