### PR TITLE
Use `default` condition instead of `import`

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.js"
+      "default": "./dist/index.js"
     }
   },
   "engines": {


### PR DESCRIPTION
Modern node versions allow `require(esm)` so there is no strong reason to only specify the `import` condition here