### PR TITLE
Complete Sprites SDK API surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,16 +48,25 @@ const client = new SpritesClient(token, options);
 **Options:**
 - `baseURL`: API base URL (default: https://api.sprites.dev)
 - `timeout`: HTTP request timeout in ms (default: 30000)
+- `controlMode`: use multiplexed control connections for supported operations (default: false)
 
 **Methods:**
 - `sprite(name: string): Sprite` - Get a handle to a sprite
-- `createSprite(name: string, config?: SpriteConfig): Promise<Sprite>` - Create a new sprite
+- `createSprite(name: string, options?: CreateSpriteOptions): Promise<Sprite>` - Create a new sprite
+- `createSprite(name: string, config?: SpriteConfig, options?: Omit<CreateSpriteOptions, 'config'>): Promise<Sprite>` - Backward-compatible creation form
 - `getSprite(name: string): Promise<Sprite>` - Get sprite information
 - `listSprites(options?: ListOptions): Promise<SpriteList>` - List sprites
+- `watchSprites(options?): Promise<SpriteListStream>` - Stream live sprite state and organization counts
 - `listAllSprites(prefix?: string): Promise<Sprite[]>` - List all sprites (handles pagination)
 - `deleteSprite(name: string): Promise<void>` - Delete a sprite
 - `upgradeSprite(name: string): Promise<void>` - Upgrade a sprite
+- `restartSprite(name: string): Promise<RestartSpriteResult>` - Restart the backing machine
+- `checkSprite(name: string): Promise<SpriteCheck>` - Check sprite health
+- `updateSprite(name: string, options: UpdateSpriteOptions): Promise<Sprite>` - Update URL settings and/or labels
+- `updateURLSettings(name: string, settings: URLSettings): Promise<void>` - Update only URL access settings
 - `static createToken(flyMacaroon: string, orgSlug: string, inviteCode?: string): Promise<string>` - Create an access token
+
+Creation options include `config`, `environment`, `urlSettings`, `labels`, `waitForCapacity`, and the `default` or `dev` `runtime`. List options include `prefix`, `maxResults`, `continuationToken`, and `bulkLoad`.
 
 ### Sprite
 
@@ -87,7 +96,31 @@ execFile(file: string, args?: string[], options?: ExecOptions): Promise<ExecResu
 
 **Management Methods:**
 - `delete(): Promise<void>` - Delete the sprite
+- `destroy(): Promise<void>` - Alias for delete
 - `upgrade(): Promise<void>` - Upgrade the sprite
+- `restart(): Promise<RestartSpriteResult>` - Restart the backing machine
+- `check(): Promise<SpriteCheck>` - Check sprite health
+- `update(options: UpdateSpriteOptions): Promise<Sprite>` - Update URL settings and/or labels
+- `updateURLSettings(settings: URLSettings): Promise<void>` - Update URL access settings
+
+`Sprite` also exposes checkpoint, service, network-policy, filesystem, port-proxy, and control-connection methods. All resource names and IDs are safely path-encoded by the SDK.
+
+Current environment APIs include:
+
+- `execFileHTTP(...)` for non-TTY execution without WebSockets
+- `killSession(...)` with an async iterable progress stream
+- `watchPorts()` for snapshots and live port events
+- `restartService(...)` and `getServiceLogs(...)`
+- network, privileges, and resource policy get/update/delete operations
+- filesystem ownership changes and live filesystem watching
+
+> **HTTP exec protocol limitation:** The current `execFileHTTP` response format
+> prefixes each frame with a type byte but does not include a frame length. HTTP
+> intermediaries are allowed to split or combine transport chunks, so the SDK
+> cannot reliably reconstruct large or high-volume output. The method rejects
+> unrecognized frame types and supports `signal` and `timeout` cancellation, but
+> combined frames can remain ambiguous. Prefer the WebSocket-based `exec` or
+> `execFile` methods until the server protocol provides explicit frame lengths.
 
 ### SpriteCommand
 
@@ -211,13 +244,24 @@ try {
 ```typescript
 // Create a sprite
 const sprite = await client.createSprite('my-sprite', {
-  ramMB: 512,
-  cpus: 1,
-  region: 'ord',
+  config: {
+    ramMB: 512,
+    cpus: 1,
+    region: 'ord',
+  },
+  urlSettings: { auth: 'sprite', privateAccess: 'admins' },
+  labels: ['development'],
+  waitForCapacity: true,
+  runtime: 'dev',
 });
 
 // List sprites
 const sprites = await client.listAllSprites();
+
+// Update and inspect lifecycle state
+await sprite.update({ labels: ['development', 'typescript'] });
+const health = await sprite.check();
+await sprite.restart();
 
 // Delete a sprite
 await sprite.delete();
@@ -226,4 +270,3 @@ await sprite.delete();
 ## License
 
 MIT
-

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fly/sprites",
-  "version": "0.0.1-dev",
+  "version": "0.0.2-dev",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@fly/sprites",
-      "version": "0.0.1-dev",
+      "version": "0.0.2-dev",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^24.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fly/sprites",
-  "version": "0.0.2-dev",
+  "version": "0.1.0-dev",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@fly/sprites",
-      "version": "0.0.2-dev",
+      "version": "0.1.0-dev",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^24.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fly/sprites",
-  "version": "0.0.1-dev",
+  "version": "0.0.2-dev",
   "description": "JavaScript/TypeScript SDK for Sprites - remote command execution",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -54,4 +54,3 @@
     "typescript": "^5.6.0"
   }
 }
-

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fly/sprites",
-  "version": "0.0.2-dev",
+  "version": "0.1.0-dev",
   "description": "JavaScript/TypeScript SDK for Sprites - remote command execution",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/client.test.ts
+++ b/src/client.test.ts
@@ -1,0 +1,219 @@
+import assert from 'node:assert/strict';
+import { afterEach, describe, it } from 'node:test';
+import { SpritesClient } from './client.js';
+import { APIError } from './types.js';
+import type { HTTPExecOptions, SpriteInfo, SpriteList, URLSettings } from './types.js';
+
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+function jsonResponse(body: unknown, status = 200, headers?: Record<string, string>): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json', ...headers },
+  });
+}
+
+function captureFetch(...responses: Response[]) {
+  const calls: Array<{ url: string; init?: RequestInit }> = [];
+  globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
+    calls.push({ url: input.toString(), init });
+    const response = responses.shift();
+    if (!response) throw new Error('Unexpected fetch');
+    return response;
+  }) as typeof fetch;
+  return calls;
+}
+
+const spriteJSON = {
+  id: 'sprite-1',
+  name: 'hello world',
+  organization: 'test-org',
+  status: 'running',
+  config: { ram_mb: 4096, cpus: 8, region: 'ord', storage_gb: 10 },
+  created_at: '2026-07-20T10:00:00Z',
+  updated_at: '2026-07-20T11:00:00Z',
+  bucket_name: 'bucket',
+  primary_region: 'ord',
+  url: 'https://hello.sprites.app',
+  url_settings: { auth: 'sprite', private_access: 'admins' },
+  version: '1.2.3',
+  environment_version: '4.5.6',
+  labels: ['sdk', 'test'],
+  last_running_at: '2026-07-20T10:30:00Z',
+  last_warming_at: '2026-07-20T10:20:00Z',
+};
+
+describe('SpritesClient public interface', () => {
+  it('preserves compatible optional response fields and extensible URL auth values', () => {
+    const info: SpriteInfo = {
+      id: 'sprite-1',
+      name: 'demo',
+      organization: 'test-org',
+      status: 'running',
+      createdAt: new Date(0),
+      updatedAt: new Date(0),
+    };
+    const list: SpriteList = { sprites: [info], hasMore: false };
+    const settings: URLSettings = { auth: 'future-api-auth-mode' };
+    // @ts-expect-error HTTP exec cannot create detachable sessions.
+    const unsupported: HTTPExecOptions = { detachable: true };
+
+    assert.equal(list.sprites[0].labels, undefined);
+    assert.equal(list.running, undefined);
+    assert.equal(settings.auth, 'future-api-auth-mode');
+    void unsupported;
+  });
+
+  it('constructs handles and preserves client options', () => {
+    const client = new SpritesClient('token', {
+      baseURL: 'https://example.test///',
+      timeout: 1234,
+      controlMode: true,
+    });
+    assert.equal(client.baseURL, 'https://example.test');
+    assert.equal(client.token, 'token');
+    assert.equal(client.controlMode, true);
+    assert.equal(client.sprite('demo').name, 'demo');
+  });
+
+  it('creates a Sprite with every current API option and maps response metadata', async () => {
+    const calls = captureFetch(jsonResponse(spriteJSON, 201));
+    const client = new SpritesClient('token', { baseURL: 'https://example.test' });
+    const sprite = await client.createSprite('hello world', {
+      config: { ramMB: 4096, cpus: 8, region: 'ord', storageGB: 10 },
+      environment: { MODE: 'test' },
+      urlSettings: { auth: 'sprite', privateAccess: 'admins' },
+      labels: ['sdk', 'test'],
+      waitForCapacity: true,
+      runtime: 'dev',
+    });
+
+    assert.deepEqual(JSON.parse(calls[0].init?.body as string), {
+      name: 'hello world',
+      config: { ram_mb: 4096, cpus: 8, region: 'ord', storage_gb: 10 },
+      environment: { MODE: 'test' },
+      url_settings: { auth: 'sprite', private_access: 'admins' },
+      labels: ['sdk', 'test'],
+      wait_for_capacity: true,
+      runtime: 'dev',
+    });
+    assert.equal(sprite.config?.ramMB, 4096);
+    assert.equal(sprite.organizationName, 'test-org');
+    assert.equal(sprite.urlSettings?.privateAccess, 'admins');
+    assert.deepEqual(sprite.labels, ['sdk', 'test']);
+    assert.equal(sprite.version, '1.2.3');
+    assert.equal(sprite.environmentVersion, '4.5.6');
+    assert.equal(sprite.lastRunningAt?.toISOString(), '2026-07-20T10:30:00.000Z');
+  });
+
+  it('keeps the legacy createSprite(name, config, options) signature', async () => {
+    const calls = captureFetch(jsonResponse(spriteJSON, 201));
+    const client = new SpritesClient('token', { baseURL: 'https://example.test' });
+    await client.createSprite(
+      'demo',
+      { ramMB: 1024 },
+      { labels: ['legacy'], urlSettings: { auth: 'public' } }
+    );
+    assert.deepEqual(JSON.parse(calls[0].init?.body as string), {
+      name: 'demo',
+      config: { ram_mb: 1024 },
+      labels: ['legacy'],
+      url_settings: { auth: 'public' },
+    });
+  });
+
+  it('gets, lists, and automatically paginates Sprites', async () => {
+    const calls = captureFetch(
+      jsonResponse(spriteJSON),
+      jsonResponse({ sprites: [spriteJSON], has_more: true, next_continuation_token: 'next', running: 1, warm: 2, cold: 3, name: 'test-org', running_limit: 10, warm_limit: 20 }),
+      jsonResponse({ sprites: [spriteJSON], has_more: true, next_continuation_token: 'next' }),
+      jsonResponse({ sprites: [{ ...spriteJSON, name: 'second' }], has_more: false })
+    );
+    const client = new SpritesClient('token', { baseURL: 'https://example.test' });
+
+    assert.equal((await client.getSprite('hello world')).id, 'sprite-1');
+    const page = await client.listSprites({ prefix: 'hello ', maxResults: 10, continuationToken: 'a/b', bulkLoad: true });
+    assert.deepEqual({ running: page.running, warm: page.warm, cold: page.cold }, { running: 1, warm: 2, cold: 3 });
+    assert.deepEqual(
+      { name: page.organizationName, runningLimit: page.runningLimit, warmLimit: page.warmLimit },
+      { name: 'test-org', runningLimit: 10, warmLimit: 20 }
+    );
+    const query = new URL(calls[1].url).searchParams;
+    assert.equal(query.get('bulk_load'), 'true');
+    assert.equal(query.get('continuation_token'), 'a/b');
+
+    const all = await client.listAllSprites('hello');
+    assert.deepEqual(all.map(sprite => sprite.name), ['hello world', 'second']);
+    assert.match(calls[0].url, /hello%20world$/);
+  });
+
+  it('streams real-time Sprite state and organization counts', async () => {
+    const calls = captureFetch(new Response(
+      '{"name":"demo","status":"running","running_version":"1.2.3","last_running_at":"2026-07-20T10:00:00Z","org":{"name":"test-org","running":1,"warm":2,"cold":3,"running_limit":10,"warm_limit":20}}\n'
+    ));
+    const client = new SpritesClient('token', { baseURL: 'https://example.test' });
+    const stream = await client.watchSprites({ prefix: 'dev-', maxResults: 5 });
+    const event = await stream.next();
+    assert.equal(event?.runningVersion, '1.2.3');
+    assert.equal(event?.lastRunningAt?.toISOString(), '2026-07-20T10:00:00.000Z');
+    assert.deepEqual(event?.organization, {
+      name: 'test-org', running: 1, warm: 2, cold: 3, runningLimit: 10, warmLimit: 20,
+    });
+    assert.equal((calls[0].init?.headers as Record<string, string>).Accept, 'application/x-ndjson');
+    assert.equal(new URL(calls[0].url).searchParams.get('prefix'), 'dev-');
+  });
+
+  it('deletes, upgrades, restarts, and checks a Sprite', async () => {
+    const calls = captureFetch(
+      new Response(null, { status: 204 }),
+      new Response(null, { status: 204 }),
+      jsonResponse({ sprite_name: 'hello world', machine_id: 'machine-1', message: 'queued' }, 202),
+      jsonResponse({ sprite_name: 'hello world', sprite_id: 'sprite-1', status: 'ok', reason: null, checked_at: '2026-07-20T12:00:00Z', elapsed: 0.25 })
+    );
+    const client = new SpritesClient('token', { baseURL: 'https://example.test' });
+    await client.deleteSprite('hello world');
+    await client.upgradeSprite('hello world');
+    assert.deepEqual(await client.restartSprite('hello world'), {
+      spriteName: 'hello world', machineId: 'machine-1', message: 'queued',
+    });
+    const check = await client.checkSprite('hello world');
+    assert.equal(check.checkedAt.toISOString(), '2026-07-20T12:00:00.000Z');
+    assert.equal(check.reason, undefined);
+    assert.ok(calls.every(call => call.url.includes('hello%20world')));
+  });
+
+  it('updates URL settings and labels and rejects an empty update', async () => {
+    const calls = captureFetch(jsonResponse(spriteJSON), jsonResponse(spriteJSON));
+    const client = new SpritesClient('token', { baseURL: 'https://example.test' });
+    await client.updateURLSettings('hello world', { auth: 'public', privateAccess: 'admins' });
+    const updated = await client.updateSprite('hello world', { labels: [] });
+    assert.equal(updated.name, 'hello world');
+    assert.deepEqual(JSON.parse(calls[0].init?.body as string), {
+      url_settings: { auth: 'public', private_access: 'admins' },
+    });
+    assert.deepEqual(JSON.parse(calls[1].init?.body as string), { labels: [] });
+    await assert.rejects(() => client.updateSprite('demo', {}), /urlSettings or labels is required/);
+  });
+
+  it('creates access tokens and encodes organization slugs', async () => {
+    const calls = captureFetch(jsonResponse({ token: 'sprite-token' }, 201));
+    assert.equal(await SpritesClient.createToken('fly-token', 'org/name', 'invite'), 'sprite-token');
+    assert.match(calls[0].url, /organizations\/org%2Fname\/tokens$/);
+    assert.deepEqual(JSON.parse(calls[0].init?.body as string), {
+      description: 'Sprite SDK Token', invite_code: 'invite',
+    });
+  });
+
+  it('surfaces structured API and network errors', async () => {
+    captureFetch(jsonResponse({ error: 'limited', error_code: 'sprite_creation_rate_limited' }, 429));
+    const client = new SpritesClient('token', { baseURL: 'https://example.test' });
+    await assert.rejects(() => client.getSprite('demo'), APIError);
+
+    globalThis.fetch = (async () => { throw new Error('offline'); }) as typeof fetch;
+    await assert.rejects(() => client.getSprite('demo'), /Network error: offline/);
+  });
+});

--- a/src/client.ts
+++ b/src/client.ts
@@ -11,8 +11,46 @@ import type {
   SpriteList,
   ListOptions,
   CreateSpriteRequest,
+  CreateSpriteOptions,
+  UpdateSpriteOptions,
+  RestartSpriteResult,
+  SpriteCheck,
+  SpriteStateEvent,
   URLSettings,
 } from './types.js';
+import { NDJSONStream } from './ndjson.js';
+
+const CREATE_SPRITE_OPTION_KEYS = {
+  config: true,
+  environment: true,
+  urlSettings: true,
+  labels: true,
+  waitForCapacity: true,
+  runtime: true,
+} as const satisfies Record<keyof CreateSpriteOptions, true>;
+
+/** Stream returned by the real-time Sprite listing endpoint. */
+export class SpriteListStream extends NDJSONStream<SpriteStateEvent> {
+  constructor(response: Response) {
+    super(response, data => ({
+      type: data.type,
+      name: data.name,
+      status: data.status,
+      runningVersion: data.running_version,
+      lastRunningAt: data.last_running_at ? new Date(data.last_running_at) : undefined,
+      lastWarmingAt: data.last_warming_at ? new Date(data.last_warming_at) : undefined,
+      timestamp: data.timestamp ? new Date(data.timestamp) : undefined,
+      organization: {
+        name: data.org?.name,
+        running: data.org?.running ?? 0,
+        warm: data.org?.warm ?? 0,
+        cold: data.org?.cold ?? 0,
+        runningLimit: data.org?.running_limit,
+        warmLimit: data.org?.warm_limit,
+      },
+    }));
+  }
+}
 
 /**
  * Map API snake_case response to camelCase SpriteInfo fields
@@ -21,15 +59,38 @@ function spriteFromAPI(data: any): SpriteInfo {
   return {
     id: data.id,
     name: data.name,
-    organization: data.organization,
+    organization: data.organization ?? data.org_slug,
     status: data.status,
-    config: data.config,
+    config: data.config ? {
+      ramMB: data.config.ram_mb,
+      cpus: data.config.cpus,
+      region: data.config.region,
+      storageGB: data.config.storage_gb,
+    } : undefined,
     environment: data.environment,
     createdAt: data.created_at ? new Date(data.created_at) : undefined,
     updatedAt: data.updated_at ? new Date(data.updated_at) : undefined,
     url: data.url,
-    urlSettings: data.url_settings,
+    urlSettings: data.url_settings ? {
+      auth: data.url_settings.auth,
+      privateAccess: data.url_settings.private_access,
+    } : undefined,
+    bucketName: data.bucket_name,
+    primaryRegion: data.primary_region,
+    version: data.version,
+    environmentVersion: data.environment_version,
+    labels: Array.isArray(data.labels) ? data.labels : [],
+    lastRunningAt: data.last_running_at ? new Date(data.last_running_at) : undefined,
+    lastWarmingAt: data.last_warming_at ? new Date(data.last_warming_at) : undefined,
   } as SpriteInfo;
+}
+
+function spriteFromInfo(info: SpriteInfo, client: SpritesClient): Sprite {
+  const sprite = new Sprite(info.name, client);
+  const { organization, ...fields } = info;
+  Object.assign(sprite, fields);
+  sprite.organizationName = organization;
+  return sprite;
 }
 
 /**
@@ -58,8 +119,25 @@ export class SpritesClient {
   /**
    * Create a new sprite
    */
-  async createSprite(name: string, config?: SpriteConfig): Promise<Sprite> {
-    const request: CreateSpriteRequest = { name, config };
+  async createSprite(name: string, config?: SpriteConfig): Promise<Sprite>;
+  async createSprite(name: string, options?: CreateSpriteOptions): Promise<Sprite>;
+  async createSprite(
+    name: string,
+    config: SpriteConfig | undefined,
+    options: Omit<CreateSpriteOptions, 'config'>
+  ): Promise<Sprite>;
+  async createSprite(
+    name: string,
+    configOrOptions?: SpriteConfig | CreateSpriteOptions,
+    extraOptions: Omit<CreateSpriteOptions, 'config'> = {}
+  ): Promise<Sprite> {
+    const value = configOrOptions ?? {};
+    const isOptions = (Object.keys(CREATE_SPRITE_OPTION_KEYS) as Array<keyof CreateSpriteOptions>)
+      .some(key => key in value);
+    const options: CreateSpriteOptions = isOptions
+      ? value as CreateSpriteOptions
+      : { ...(configOrOptions !== undefined && { config: value as SpriteConfig }), ...extraOptions };
+    const request: CreateSpriteRequest = { name, ...options };
 
     const response = await this.fetch(`${this.baseURL}/v1/sprites`, {
       method: 'POST',
@@ -67,7 +145,7 @@ export class SpritesClient {
         'Authorization': `Bearer ${this.token}`,
         'Content-Type': 'application/json',
       },
-      body: JSON.stringify(request),
+      body: JSON.stringify(toAPIRequest(request)),
       signal: AbortSignal.timeout(120000), // 2 minute timeout for creation
     });
 
@@ -80,16 +158,14 @@ export class SpritesClient {
     }
 
     const info = spriteFromAPI(await response.json());
-    const sprite = new Sprite(info.name, this);
-    Object.assign(sprite, info);
-    return sprite;
+    return spriteFromInfo(info, this);
   }
 
   /**
    * Get information about a sprite
    */
   async getSprite(name: string): Promise<Sprite> {
-    const response = await this.fetch(`${this.baseURL}/v1/sprites/${name}`, {
+    const response = await this.fetch(`${this.baseURL}/v1/sprites/${encodeURIComponent(name)}`, {
       method: 'GET',
       headers: {
         'Authorization': `Bearer ${this.token}`,
@@ -106,9 +182,7 @@ export class SpritesClient {
     }
 
     const info = spriteFromAPI(await response.json());
-    const sprite = new Sprite(info.name, this);
-    Object.assign(sprite, info);
-    return sprite;
+    return spriteFromInfo(info, this);
   }
 
   /**
@@ -119,8 +193,10 @@ export class SpritesClient {
     if (options.maxResults) params.set('max_results', options.maxResults.toString());
     if (options.continuationToken) params.set('continuation_token', options.continuationToken);
     if (options.prefix) params.set('prefix', options.prefix);
+    if (options.bulkLoad) params.set('bulk_load', 'true');
 
-    const url = `${this.baseURL}/v1/sprites?${params}`;
+    const query = params.toString();
+    const url = `${this.baseURL}/v1/sprites${query ? `?${query}` : ''}`;
     const response = await this.fetch(url, {
       method: 'GET',
       headers: {
@@ -142,7 +218,35 @@ export class SpritesClient {
       sprites: (data.sprites || []).map(spriteFromAPI),
       hasMore: data.has_more || false,
       nextContinuationToken: data.next_continuation_token,
+      running: data.running ?? 0,
+      warm: data.warm ?? 0,
+      cold: data.cold ?? 0,
+      organizationName: data.name,
+      runningLimit: data.running_limit,
+      warmLimit: data.warm_limit,
     } as SpriteList;
+  }
+
+  /** Watch Sprite state and organization count updates as NDJSON. */
+  async watchSprites(options: Pick<ListOptions, 'prefix' | 'maxResults'> = {}): Promise<SpriteListStream> {
+    const params = new URLSearchParams();
+    if (options.prefix) params.set('prefix', options.prefix);
+    if (options.maxResults) params.set('max_results', options.maxResults.toString());
+    const query = params.toString();
+    const response = await this.fetch(`${this.baseURL}/v1/sprites${query ? `?${query}` : ''}`, {
+      method: 'GET',
+      headers: {
+        'Authorization': `Bearer ${this.token}`,
+        'Accept': 'application/x-ndjson',
+      },
+    });
+    if (!response.ok) {
+      const body = await response.text();
+      const error = parseAPIError(response.status, body, Object.fromEntries(response.headers.entries()));
+      if (error) throw error;
+      throw new Error(`Failed to watch sprites (status ${response.status}): ${body}`);
+    }
+    return new SpriteListStream(response);
   }
 
   /**
@@ -155,14 +259,12 @@ export class SpritesClient {
     do {
       const result = await this.listSprites({
         prefix,
-        maxResults: 100,
+        maxResults: 50,
         continuationToken,
       });
 
       for (const info of result.sprites) {
-        const sprite = new Sprite(info.name, this);
-        Object.assign(sprite, info);
-        allSprites.push(sprite);
+        allSprites.push(spriteFromInfo(info, this));
       }
 
       continuationToken = result.hasMore ? result.nextContinuationToken : undefined;
@@ -175,7 +277,7 @@ export class SpritesClient {
    * Delete a sprite
    */
   async deleteSprite(name: string): Promise<void> {
-    const response = await this.fetch(`${this.baseURL}/v1/sprites/${name}`, {
+    const response = await this.fetch(`${this.baseURL}/v1/sprites/${encodeURIComponent(name)}`, {
       method: 'DELETE',
       headers: {
         'Authorization': `Bearer ${this.token}`,
@@ -196,7 +298,7 @@ export class SpritesClient {
    * Upgrade a sprite to the latest version
    */
   async upgradeSprite(name: string): Promise<void> {
-    const response = await this.fetch(`${this.baseURL}/v1/sprites/${name}/upgrade`, {
+    const response = await this.fetch(`${this.baseURL}/v1/sprites/${encodeURIComponent(name)}/upgrade`, {
       method: 'POST',
       headers: {
         'Authorization': `Bearer ${this.token}`,
@@ -213,19 +315,67 @@ export class SpritesClient {
     }
   }
 
+  /** Restart the machine backing a Sprite. */
+  async restartSprite(name: string): Promise<RestartSpriteResult> {
+    const response = await this.fetch(
+      `${this.baseURL}/v1/sprites/${encodeURIComponent(name)}/restart`,
+      {
+        method: 'POST',
+        headers: { 'Authorization': `Bearer ${this.token}` },
+        signal: AbortSignal.timeout(60000),
+      }
+    );
+    const data = await this.readJSON(response, 'restart sprite');
+    return {
+      spriteName: data.sprite_name,
+      machineId: data.machine_id,
+      message: data.message,
+    };
+  }
+
+  /** Check the health of a Sprite. */
+  async checkSprite(name: string): Promise<SpriteCheck> {
+    const response = await this.fetch(
+      `${this.baseURL}/v1/sprites/${encodeURIComponent(name)}/check`,
+      {
+        method: 'GET',
+        headers: { 'Authorization': `Bearer ${this.token}` },
+        signal: AbortSignal.timeout(this.timeout),
+      }
+    );
+    const data = await this.readJSON(response, 'check sprite');
+    return {
+      spriteName: data.sprite_name,
+      spriteId: data.sprite_id,
+      status: data.status,
+      reason: data.reason ?? undefined,
+      checkedAt: new Date(data.checked_at),
+      elapsed: data.elapsed ?? undefined,
+    };
+  }
+
   /**
    * Update URL authentication settings for a sprite
    * @param name - Sprite name
    * @param settings - URL settings with auth: "public" for no auth, "sprite" for authenticated
    */
   async updateURLSettings(name: string, settings: URLSettings): Promise<void> {
-    const response = await this.fetch(`${this.baseURL}/v1/sprites/${name}`, {
+    await this.updateSprite(name, { urlSettings: settings });
+  }
+
+  /** Partially update mutable Sprite settings and return the updated Sprite. */
+  async updateSprite(name: string, options: UpdateSpriteOptions): Promise<Sprite> {
+    if (options.urlSettings === undefined && options.labels === undefined) {
+      throw new TypeError('urlSettings or labels is required');
+    }
+
+    const response = await this.fetch(`${this.baseURL}/v1/sprites/${encodeURIComponent(name)}`, {
       method: 'PUT',
       headers: {
         'Authorization': `Bearer ${this.token}`,
         'Content-Type': 'application/json',
       },
-      body: JSON.stringify({ url_settings: settings }),
+      body: JSON.stringify(toAPIRequest(options)),
       signal: AbortSignal.timeout(this.timeout),
     });
 
@@ -234,8 +384,11 @@ export class SpritesClient {
       const headers = Object.fromEntries(response.headers.entries());
       const apiErr = parseAPIError(response.status, body, headers);
       if (apiErr) throw apiErr;
-      throw new Error(`Failed to update URL settings (status ${response.status}): ${body}`);
+      throw new Error(`Failed to update sprite (status ${response.status}): ${body}`);
     }
+
+    const info = spriteFromAPI(await response.json());
+    return spriteFromInfo({ ...info, name: info.name || name }, this);
   }
 
   /**
@@ -247,7 +400,7 @@ export class SpritesClient {
     inviteCode?: string
   ): Promise<string> {
     const apiURL = 'https://api.sprites.dev';
-    const url = `${apiURL}/v1/organizations/${orgSlug}/tokens`;
+    const url = `${apiURL}/v1/organizations/${encodeURIComponent(orgSlug)}/tokens`;
 
     const body: any = {
       description: 'Sprite SDK Token',
@@ -296,5 +449,32 @@ export class SpritesClient {
       throw error;
     }
   }
+
+  private async readJSON(response: Response, operation: string): Promise<any> {
+    if (!response.ok) {
+      const body = await response.text();
+      const headers = Object.fromEntries(response.headers.entries());
+      const apiErr = parseAPIError(response.status, body, headers);
+      if (apiErr) throw apiErr;
+      throw new Error(`Failed to ${operation} (status ${response.status}): ${body}`);
+    }
+    return response.json();
+  }
 }
 
+/** Convert SDK camelCase request objects to the API's snake_case JSON. */
+function toAPIRequest(value: any, preserveKeys = false): any {
+  if (Array.isArray(value)) return value.map(item => toAPIRequest(item, preserveKeys));
+  if (value === null || typeof value !== 'object') return value;
+
+  const result: Record<string, any> = {};
+  for (const [key, item] of Object.entries(value)) {
+    if (item === undefined) continue;
+    const apiKey = preserveKeys ? key : key
+      .replace(/([a-z0-9])([A-Z])/g, '$1_$2')
+      .replace(/([A-Z])([A-Z][a-z])/g, '$1_$2')
+      .toLowerCase();
+    result[apiKey] = toAPIRequest(item, preserveKeys || key === 'environment');
+  }
+  return result;
+}

--- a/src/control.ts
+++ b/src/control.ts
@@ -247,7 +247,7 @@ export class ControlConnection extends EventEmitter {
       baseURL = 'ws' + baseURL.substring(4);
     }
 
-    const url = `${baseURL}/v1/sprites/${this.sprite.name}/control`;
+    const url = `${baseURL}/v1/sprites/${encodeURIComponent(this.sprite.name)}/control`;
 
     return new Promise((resolve, reject) => {
       try {

--- a/src/exec.ts
+++ b/src/exec.ts
@@ -7,7 +7,22 @@ import { Readable, Writable, PassThrough } from 'node:stream';
 import { WSCommand } from './websocket.js';
 import type { Sprite } from './sprite.js';
 import type { SpawnOptions, ExecOptions, ExecResult } from './types.js';
+import type { HTTPExecOptions, SessionKillEvent } from './types.js';
 import { ExecError } from './types.js';
+import { parseAPIError } from './types.js';
+import { NDJSONStream } from './ndjson.js';
+
+export class SessionKillStream extends NDJSONStream<SessionKillEvent> {
+  constructor(response: Response) {
+    super(response, data => ({
+      type: data.type,
+      message: data.message,
+      signal: data.signal,
+      pid: data.pid,
+      exitCode: data.exit_code,
+    }));
+  }
+}
 
 /**
  * Represents a command running on a sprite
@@ -138,9 +153,9 @@ export class SpriteCommand extends EventEmitter {
     // Use /exec/{id} for attach, /exec for new commands
     let path: string;
     if (options.sessionId) {
-      path = `/v1/sprites/${this.sprite.name}/exec/${options.sessionId}`;
+      path = `/v1/sprites/${encodeURIComponent(this.sprite.name)}/exec/${encodeURIComponent(options.sessionId)}`;
     } else {
-      path = `/v1/sprites/${this.sprite.name}/exec`;
+      path = `/v1/sprites/${encodeURIComponent(this.sprite.name)}/exec`;
     }
 
     const url = new URL(`${baseURL}${path}`);
@@ -188,6 +203,10 @@ export class SpriteCommand extends EventEmitter {
     // Add control mode flag
     if (options.controlMode) {
       url.searchParams.set('cc', 'true');
+    }
+
+    if (options.maxRunAfterDisconnect) {
+      url.searchParams.set('max_run_after_disconnect', options.maxRunAfterDisconnect);
     }
 
     return url.toString();
@@ -338,6 +357,134 @@ export async function execFile(
 }
 
 /**
+ * Execute a non-TTY command over HTTP for environments without WebSockets.
+ *
+ * The current server protocol uses type-prefixed frames without lengths and
+ * therefore relies on HTTP transport chunk boundaries being preserved. This
+ * method rejects frame types that reveal re-chunking, but cannot detect every
+ * coalesced frame. Prefer the WebSocket exec methods for large output.
+ */
+export async function execFileHTTP(
+  sprite: Sprite,
+  file: string,
+  args: string[] = [],
+  options: HTTPExecOptions = {}
+): Promise<ExecResult> {
+  const url = new URL(`${sprite.client.baseURL}/v1/sprites/${encodeURIComponent(sprite.name)}/exec`);
+  for (const value of [file, ...args]) url.searchParams.append('cmd', value);
+  url.searchParams.set('path', file);
+  if (options.cwd) url.searchParams.set('dir', options.cwd);
+  for (const [key, value] of Object.entries(options.env ?? {})) {
+    url.searchParams.append('env', `${key}=${value}`);
+  }
+  if (options.input !== undefined) url.searchParams.set('stdin', 'true');
+
+  if (options.timeout !== undefined &&
+      (!Number.isFinite(options.timeout) || options.timeout < 0)) {
+    throw new TypeError('timeout must be a non-negative finite number');
+  }
+  const signals = [
+    options.signal,
+    options.timeout === undefined ? undefined : AbortSignal.timeout(options.timeout),
+  ].filter((signal): signal is AbortSignal => signal !== undefined);
+  const requestSignal = signals.length > 1 ? AbortSignal.any(signals) : signals[0];
+
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: {
+      'Authorization': `Bearer ${sprite.client.token}`,
+      'Content-Type': 'application/octet-stream',
+    },
+    body: options.input === undefined ? undefined :
+      typeof options.input === 'string' ? Buffer.from(options.input) : options.input,
+    signal: requestSignal,
+  });
+  if (!response.ok) {
+    const body = await response.text();
+    const error = parseAPIError(response.status, body, Object.fromEntries(response.headers.entries()));
+    if (error) throw error;
+    throw new Error(`Failed to execute command over HTTP (status ${response.status}): ${body}`);
+  }
+  if (!response.body) throw new Error('HTTP exec response has no body');
+
+  const stdout: Buffer[] = [];
+  const stderr: Buffer[] = [];
+  let stdoutLength = 0;
+  let stderrLength = 0;
+  let exitCode = -1;
+  const maxBuffer = options.maxBuffer || 10 * 1024 * 1024;
+  const reader = response.body.getReader();
+  try {
+    while (true) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      if (!value?.length) continue;
+      const frameType = value[0];
+      const payload = Buffer.from(value.subarray(1));
+      if (frameType === 1) {
+        stdoutLength += payload.length;
+        if (stdoutLength > maxBuffer) throw new Error('stdout maxBuffer exceeded');
+        stdout.push(payload);
+      } else if (frameType === 2) {
+        stderrLength += payload.length;
+        if (stderrLength > maxBuffer) throw new Error('stderr maxBuffer exceeded');
+        stderr.push(payload);
+      } else if (frameType === 3) {
+        if (payload.length !== 1) {
+          throw new Error(
+            `Invalid HTTP exec exit frame length ${payload.length}; ` +
+            'the server protocol requires preserved HTTP chunk boundaries'
+          );
+        }
+        exitCode = payload[0] ?? 255;
+      } else {
+        throw new Error(
+          `Unsupported HTTP exec frame type 0x${frameType.toString(16).padStart(2, '0')}; ` +
+          'the server protocol requires preserved HTTP chunk boundaries'
+        );
+      }
+    }
+    if (exitCode < 0) throw new Error('HTTP exec response did not include an exit frame');
+  } finally {
+    await reader.cancel().catch(() => undefined);
+  }
+
+  const stdoutBuffer = Buffer.concat(stdout);
+  const stderrBuffer = Buffer.concat(stderr);
+  const encoding = options.encoding || 'utf8';
+  const result: ExecResult = {
+    stdout: encoding === ('buffer' as any) ? stdoutBuffer : stdoutBuffer.toString(encoding),
+    stderr: encoding === ('buffer' as any) ? stderrBuffer : stderrBuffer.toString(encoding),
+    exitCode,
+  };
+  if (exitCode !== 0) throw new ExecError(`Command failed with exit code ${exitCode}`, result);
+  return result;
+}
+
+/** Kill an active exec session and stream progress events. */
+export async function killSession(
+  sprite: Sprite,
+  sessionId: string,
+  signal?: string,
+  timeout?: string
+): Promise<SessionKillStream> {
+  const url = new URL(`${sprite.client.baseURL}/v1/sprites/${encodeURIComponent(sprite.name)}/exec/${encodeURIComponent(sessionId)}/kill`);
+  if (signal) url.searchParams.set('signal', signal);
+  if (timeout) url.searchParams.set('timeout', timeout);
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: { 'Authorization': `Bearer ${sprite.client.token}` },
+  });
+  if (!response.ok) {
+    const body = await response.text();
+    const error = parseAPIError(response.status, body, Object.fromEntries(response.headers.entries()));
+    if (error) throw error;
+    throw new Error(`Failed to kill session (status ${response.status}): ${body}`);
+  }
+  return new SessionKillStream(response);
+}
+
+/**
  * Execute a file via control connection for multiplexed operations
  */
 async function execFileViaControl(
@@ -423,4 +570,3 @@ async function execFileViaControl(
     releaseControlConnection(sprite, cc);
   }
 }
-

--- a/src/filesystem.test.ts
+++ b/src/filesystem.test.ts
@@ -1,0 +1,93 @@
+import assert from 'node:assert/strict';
+import { afterEach, describe, it } from 'node:test';
+import { SpritesClient } from './client.js';
+import { FilesystemError } from './types.js';
+
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+describe('SpriteFilesystem public interface', () => {
+  it('supports every filesystem operation and Node-like result objects', async () => {
+    const calls: Array<{ url: string; init?: RequestInit }> = [];
+    globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
+      const url = new URL(input.toString());
+      calls.push({ url: url.toString(), init });
+      const endpoint = url.pathname.split('/fs/')[1];
+      if (endpoint === 'read') {
+        if (url.searchParams.get('path') === 'missing') {
+          return new Response(JSON.stringify({ error: 'not found', code: 'ENOENT', path: 'missing' }), { status: 404 });
+        }
+        const content = url.searchParams.get('path')?.endsWith('.json') ? '{"ok":true}' : 'hello';
+        return new Response(content);
+      }
+      if (endpoint === 'list') {
+        return new Response(JSON.stringify({ path: '/app', count: 2, entries: [
+          { name: 'file.txt', path: '/app/file.txt', type: 'file', size: 5, mode: '0644', modTime: '2026-07-20T10:00:00Z', isDir: false },
+          { name: 'dir', path: '/app/dir', type: 'directory', size: 0, mode: '0755', modTime: '2026-07-20T10:00:00Z', isDir: true },
+        ] }));
+      }
+      return new Response(null, { status: endpoint === 'delete' ? 204 : 200 });
+    }) as typeof fetch;
+
+    const fs = new SpritesClient('token', { baseURL: 'https://example.test' }).sprite('demo/name').filesystem('/app');
+    assert.equal(await fs.readFile('file.txt', 'utf8'), 'hello');
+    assert.deepEqual(await fs.readFile('file.txt', null), Buffer.from('hello'));
+    await fs.writeFile('file.txt', 'data', { mode: 0o600 });
+    assert.deepEqual(await fs.readdir('.'), ['file.txt', 'dir']);
+    const entries = await fs.readdir('.', { withFileTypes: true });
+    assert.equal(entries[0].isFile(), true);
+    assert.equal(entries[0].isDirectory(), false);
+    assert.equal(entries[0].isSymbolicLink(), false);
+    assert.equal(entries[1].isDirectory(), true);
+    assert.equal(entries[0].parentPath, '.');
+    await fs.mkdir('nested/path', { recursive: true, mode: 0o755 });
+    await fs.rm('old', { recursive: true });
+
+    const stats = await fs.stat('file.txt');
+    assert.equal(stats.size, 5);
+    assert.equal(stats.mode, 0o644);
+    assert.equal(stats.isFile(), true);
+    assert.equal(stats.isDirectory(), false);
+    assert.equal(stats.isSymbolicLink(), false);
+    assert.equal(stats.mtime.toISOString(), '2026-07-20T10:00:00.000Z');
+
+    await fs.rename('old', 'new');
+    await fs.copyFile('source', 'dest', { recursive: true });
+    await fs.chmod('script.sh', 0o755, { recursive: true });
+    await fs.chown('script.sh', { uid: 'sprite', gid: 1000, recursive: true, asRoot: true });
+    assert.equal(await fs.exists('file.txt'), true);
+    await fs.appendFile('file.txt', ' world');
+    assert.deepEqual(await fs.readJSON('data.json'), { ok: true });
+    await fs.writeJSON('data.json', { ok: true }, { spaces: 2 });
+
+    assert.ok(calls.every(call => call.url.includes('/sprites/demo%2Fname/fs/')));
+    const write = calls.find(call => new URL(call.url).pathname.endsWith('/fs/write') && new URL(call.url).searchParams.get('path') === 'file.txt')!;
+    assert.equal(new URL(write.url).searchParams.get('mode'), '0600');
+    assert.deepEqual(Buffer.from(write.init?.body as Buffer), Buffer.from('data'));
+    const rename = calls.find(call => new URL(call.url).pathname.endsWith('/fs/rename'))!;
+    assert.deepEqual(JSON.parse(rename.init?.body as string), { source: 'old', dest: 'new', workingDir: '/app' });
+    const chown = calls.find(call => new URL(call.url).pathname.endsWith('/fs/chown'))!;
+    assert.deepEqual(JSON.parse(chown.init?.body as string), {
+      path: 'script.sh', workingDir: '/app', uid: 'sprite', gid: 1000, recursive: true, asRoot: true,
+    });
+    await assert.rejects(() => fs.chown('script.sh', {}), /uid or gid is required/);
+  });
+
+  it('returns FilesystemError instances and honors force removal', async () => {
+    globalThis.fetch = (async () => new Response(
+      JSON.stringify({ error: 'not found', code: 'ENOENT', path: '/missing' }),
+      { status: 404, headers: { 'content-type': 'application/json' } }
+    )) as typeof fetch;
+    const fs = new SpritesClient('token').sprite('demo').filesystem();
+
+    await assert.rejects(
+      () => fs.readFile('missing'),
+      (error: unknown) => error instanceof FilesystemError && error.code === 'ENOENT' && error.syscall === 'read'
+    );
+    assert.equal(await fs.exists('missing'), false);
+    await fs.rm('missing', { force: true });
+  });
+});

--- a/src/filesystem.ts
+++ b/src/filesystem.ts
@@ -4,16 +4,20 @@
  */
 
 import { SpritesClient } from './client.js';
+import { FilesystemError } from './types.js';
+import { FilesystemWatcher } from './watch.js';
 import type {
   Stats,
   Dirent,
-  FilesystemError,
   FilesystemErrorCode,
   ReaddirOptions,
   MkdirOptions,
   RmOptions,
   CopyFileOptions,
   ChmodOptions,
+  RenameOptions,
+  ChownOptions,
+  FilesystemWatchOptions,
   FsEntry,
   FsListResponse,
   FsErrorResponse,
@@ -92,13 +96,7 @@ function createError(
   path: string,
   syscall?: string
 ): FilesystemError {
-  // Import dynamically to avoid circular dependency
-  const error = new Error(message) as FilesystemError;
-  error.name = 'FilesystemError';
-  (error as any).code = code;
-  (error as any).path = path;
-  (error as any).syscall = syscall;
-  return error;
+  return new FilesystemError(message, code, path, syscall);
 }
 
 /**
@@ -113,6 +111,7 @@ function parseErrorCode(serverCode?: string): FilesystemErrorCode {
     'ENOTDIR': 'ENOTDIR',
     'EISDIR': 'EISDIR',
     'EACCES': 'EACCES',
+    'EPERM': 'EPERM',
     'ENOTEMPTY': 'ENOTEMPTY',
     'EINVAL': 'EINVAL',
     'EIO': 'EIO',
@@ -157,7 +156,7 @@ export class SpriteFilesystem {
    * Build the full URL for a filesystem endpoint
    */
   private buildURL(endpoint: string): string {
-    return `${this.client.baseURL}/v1/sprites/${this.spriteName}/fs${endpoint}`;
+    return `${this.client.baseURL}/v1/sprites/${encodeURIComponent(this.spriteName)}/fs${endpoint}`;
   }
 
   /**
@@ -263,12 +262,14 @@ export class SpriteFilesystem {
    * @param path - Directory path (relative to workingDir or absolute)
    * @param options - If withFileTypes is true, returns Dirent objects
    */
-  async readdir(path: string, options?: { withFileTypes?: false }): Promise<string[]>;
-  async readdir(path: string, options: { withFileTypes: true }): Promise<Dirent[]>;
+  async readdir(path: string, options?: ReaddirOptions & { withFileTypes?: false }): Promise<string[]>;
+  async readdir(path: string, options: ReaddirOptions & { withFileTypes: true }): Promise<Dirent[]>;
   async readdir(path: string, options?: ReaddirOptions): Promise<string[] | Dirent[]> {
     const url = new URL(this.buildURL('/list'));
     url.searchParams.set('path', path);
     url.searchParams.set('workingDir', this.workingDir);
+    if (options?.recursive) url.searchParams.set('recursive', 'true');
+    if (options?.pattern) url.searchParams.set('pattern', options.pattern);
 
     const response = await fetch(url.toString(), {
       method: 'GET',
@@ -343,6 +344,7 @@ export class SpriteFilesystem {
     if (options?.recursive) {
       url.searchParams.set('recursive', 'true');
     }
+    if (options?.asRoot) url.searchParams.set('asRoot', 'true');
 
     const response = await fetch(url.toString(), {
       method: 'DELETE',
@@ -389,7 +391,7 @@ export class SpriteFilesystem {
    * @param oldPath - Current path (relative to workingDir or absolute)
    * @param newPath - New path (relative to workingDir or absolute)
    */
-  async rename(oldPath: string, newPath: string): Promise<void> {
+  async rename(oldPath: string, newPath: string, options?: RenameOptions): Promise<void> {
     const url = this.buildURL('/rename');
 
     const response = await fetch(url, {
@@ -402,6 +404,7 @@ export class SpriteFilesystem {
         source: oldPath,
         dest: newPath,
         workingDir: this.workingDir,
+        asRoot: options?.asRoot,
       }),
     });
 
@@ -430,6 +433,8 @@ export class SpriteFilesystem {
         dest: dest,
         workingDir: this.workingDir,
         recursive: options?.recursive,
+        preserveAttrs: options?.preserveAttrs,
+        asRoot: options?.asRoot,
       }),
     });
 
@@ -458,6 +463,7 @@ export class SpriteFilesystem {
         workingDir: this.workingDir,
         mode: mode.toString(8).padStart(4, '0'),
         recursive: options?.recursive,
+        asRoot: options?.asRoot,
       }),
     });
 
@@ -480,6 +486,42 @@ export class SpriteFilesystem {
       }
       throw error;
     }
+  }
+
+  /** Change file ownership by numeric ID or user/group name. */
+  async chown(path: string, options: ChownOptions): Promise<void> {
+    if (options.uid === undefined && options.gid === undefined) {
+      throw new TypeError('uid or gid is required');
+    }
+    const response = await fetch(this.buildURL('/chown'), {
+      method: 'POST',
+      headers: { ...this.getHeaders(), 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        path,
+        workingDir: this.workingDir,
+        uid: options.uid,
+        gid: options.gid,
+        recursive: options.recursive,
+        asRoot: options.asRoot,
+      }),
+    });
+    if (!response.ok) await this.handleError(response, path, 'chown');
+  }
+
+  /** Watch one or more paths for filesystem changes. */
+  async watch(
+    paths: string | string[],
+    options: FilesystemWatchOptions = {}
+  ): Promise<FilesystemWatcher> {
+    const watcher = new FilesystemWatcher(
+      this.client,
+      this.spriteName,
+      Array.isArray(paths) ? paths : [paths],
+      this.workingDir,
+      options.recursive === true
+    );
+    await watcher.connect();
+    return watcher;
   }
 
   /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,14 +4,16 @@
  * Remote command execution for Sprites, with an API that mirrors Node.js child_process
  */
 
-export { SpritesClient } from './client.js';
+export { SpritesClient, SpriteListStream } from './client.js';
 export { Sprite } from './sprite.js';
 export { SpriteCommand } from './exec.js';
+export { SessionKillStream } from './exec.js';
 export { CheckpointStream, RestoreStream } from './checkpoint.js';
 export { ProxySession, ProxyManager, proxyPort, proxyPorts } from './proxy.js';
 export { ServiceLogStream } from './services.js';
 export { SpriteFilesystem } from './filesystem.js';
 export { ControlConnection, OpConn } from './control.js';
+export { PortWatcher, FilesystemWatcher } from './watch.js';
 export type { StartOpOptions } from './control.js';
 
 export type {
@@ -20,14 +22,23 @@ export type {
   SpawnOptions,
   ExecOptions,
   ExecResult,
+  HTTPExecOptions,
   SpriteInfo,
   SpriteList,
+  SpriteStateEvent,
   ListOptions,
   Session,
   PortNotification,
+  PortList,
+  PortWatchEvent,
   OrganizationInfo,
   ControlMessage,
   CreateSpriteRequest,
+  CreateSpriteOptions,
+  UpdateSpriteOptions,
+  RestartSpriteResult,
+  SpriteCheck,
+  SessionKillEvent,
   Checkpoint,
   URLSettings,
   StreamMessage,
@@ -41,6 +52,8 @@ export type {
   ServiceLogEvent,
   PolicyRule,
   NetworkPolicy,
+  PrivilegesPolicy,
+  ResourcesPolicy,
   Stats,
   Dirent,
   FilesystemErrorCode,
@@ -49,6 +62,10 @@ export type {
   RmOptions,
   CopyFileOptions,
   ChmodOptions,
+  RenameOptions,
+  ChownOptions,
+  FilesystemWatchOptions,
+  FilesystemWatchEvent,
 } from './types.js';
 
 export {
@@ -60,4 +77,3 @@ export {
   ERR_CODE_CREATION_RATE_LIMITED,
   ERR_CODE_CONCURRENT_LIMIT_EXCEEDED,
 } from './types.js';
-

--- a/src/ndjson.ts
+++ b/src/ndjson.ts
@@ -1,0 +1,58 @@
+/** Internal reusable reader for newline-delimited JSON responses. */
+export class NDJSONStream<T> implements AsyncIterable<T> {
+  private readonly reader: ReadableStreamDefaultReader<Uint8Array>;
+  private readonly decoder = new TextDecoder();
+  private buffer = '';
+  private done = false;
+
+  constructor(response: Response, private readonly map: (data: any) => T = data => data as T) {
+    if (!response.body) throw new Error('Response has no body');
+    this.reader = response.body.getReader();
+  }
+
+  async next(): Promise<T | null> {
+    if (this.done) return null;
+    while (true) {
+      const newline = this.buffer.indexOf('\n');
+      if (newline >= 0) {
+        const line = this.buffer.slice(0, newline).trim();
+        this.buffer = this.buffer.slice(newline + 1);
+        if (!line) continue;
+        try { return this.map(JSON.parse(line)); } catch { continue; }
+      }
+      const chunk = await this.reader.read();
+      if (chunk.done) {
+        this.done = true;
+        const line = this.buffer.trim();
+        this.buffer = '';
+        if (!line) return null;
+        try { return this.map(JSON.parse(line)); } catch { return null; }
+      }
+      this.buffer += this.decoder.decode(chunk.value, { stream: true });
+    }
+  }
+
+  async processAll(handler: (event: T) => void | Promise<void>): Promise<void> {
+    try {
+      let event: T | null;
+      while ((event = await this.next()) !== null) await handler(event);
+    } finally {
+      this.close();
+    }
+  }
+
+  close(): void {
+    if (this.done) return;
+    this.done = true;
+    this.reader.cancel().catch(() => {});
+  }
+
+  async *[Symbol.asyncIterator](): AsyncIterableIterator<T> {
+    try {
+      let event: T | null;
+      while ((event = await this.next()) !== null) yield event;
+    } finally {
+      this.close();
+    }
+  }
+}

--- a/src/policy.ts
+++ b/src/policy.ts
@@ -2,7 +2,7 @@
  * Network policy API handlers
  */
 
-import type { NetworkPolicy } from './types.js';
+import type { NetworkPolicy, PrivilegesPolicy, ResourcesPolicy } from './types.js';
 
 interface ClientInfo {
   baseURL: string;
@@ -17,7 +17,7 @@ export async function getNetworkPolicy(
   spriteName: string
 ): Promise<NetworkPolicy> {
   const response = await fetch(
-    `${client.baseURL}/v1/sprites/${spriteName}/policy/network`,
+    `${client.baseURL}/v1/sprites/${encodeURIComponent(spriteName)}/policy/network`,
     {
       method: 'GET',
       headers: {
@@ -46,7 +46,7 @@ export async function updateNetworkPolicy(
   policy: NetworkPolicy
 ): Promise<void> {
   const response = await fetch(
-    `${client.baseURL}/v1/sprites/${spriteName}/policy/network`,
+    `${client.baseURL}/v1/sprites/${encodeURIComponent(spriteName)}/policy/network`,
     {
       method: 'POST',
       headers: {
@@ -69,4 +69,58 @@ export async function updateNetworkPolicy(
       `Failed to update network policy (status ${response.status}): ${body}`
     );
   }
+}
+
+async function policyRequest<T>(
+  client: ClientInfo,
+  spriteName: string,
+  kind: 'privileges' | 'resources',
+  method: 'GET' | 'POST' | 'DELETE',
+  body?: unknown
+): Promise<T> {
+  const response = await fetch(
+    `${client.baseURL}/v1/sprites/${encodeURIComponent(spriteName)}/policy/${kind}`,
+    {
+      method,
+      headers: {
+        Authorization: `Bearer ${client.token}`,
+        ...(body !== undefined && { 'Content-Type': 'application/json' }),
+      },
+      ...(body !== undefined && { body: JSON.stringify(body) }),
+      signal: AbortSignal.timeout(30000),
+    }
+  );
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(`Failed to ${method.toLowerCase()} ${kind} policy (status ${response.status}): ${text}`);
+  }
+  if (method === 'GET') return response.json() as Promise<T>;
+  return undefined as T;
+}
+
+export function getPrivilegesPolicy(client: ClientInfo, spriteName: string): Promise<PrivilegesPolicy> {
+  return policyRequest(client, spriteName, 'privileges', 'GET');
+}
+
+export function updatePrivilegesPolicy(client: ClientInfo, spriteName: string, policy: PrivilegesPolicy): Promise<void> {
+  return policyRequest(client, spriteName, 'privileges', 'POST', policy);
+}
+
+export function deletePrivilegesPolicy(client: ClientInfo, spriteName: string): Promise<void> {
+  return policyRequest(client, spriteName, 'privileges', 'DELETE');
+}
+
+export async function getResourcesPolicy(client: ClientInfo, spriteName: string): Promise<ResourcesPolicy> {
+  const data = await policyRequest<any>(client, spriteName, 'resources', 'GET');
+  return { memory: data.memory ? { limitMB: data.memory.limit_mb, autoscale: data.memory.autoscale } : undefined };
+}
+
+export function updateResourcesPolicy(client: ClientInfo, spriteName: string, policy: ResourcesPolicy): Promise<void> {
+  return policyRequest(client, spriteName, 'resources', 'POST', {
+    ...(policy.memory && { memory: { limit_mb: policy.memory.limitMB, autoscale: policy.memory.autoscale } }),
+  });
+}
+
+export function deleteResourcesPolicy(client: ClientInfo, spriteName: string): Promise<void> {
+  return policyRequest(client, spriteName, 'resources', 'DELETE');
 }

--- a/src/proxy.test.ts
+++ b/src/proxy.test.ts
@@ -1,0 +1,51 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { ProxyManager, ProxySession, proxyPort, proxyPorts } from './proxy.js';
+import { SpritesClient } from './client.js';
+
+const client = { baseURL: 'https://example.test', token: 'token' };
+
+describe('proxy public interface', () => {
+  it('starts, reports, waits for, and closes ProxySession listeners', async () => {
+    const session = new ProxySession(client, 'demo', { localPort: 0, remotePort: 3000 });
+    assert.equal(session.localAddr(), null);
+    assert.equal(session.remoteHost, 'localhost');
+    await session.start();
+    assert.match(session.localAddr()!, /^localhost:\d+$/);
+    const waited = session.wait();
+    session.close();
+    await waited;
+    session.close();
+    assert.equal(session.localAddr(), null);
+  });
+
+  it('creates one or multiple proxy listeners with convenience functions', async () => {
+    const single = await proxyPort(client, 'demo', 0, 3000, '127.0.0.1');
+    assert.equal(single.remoteHost, '127.0.0.1');
+    single.close();
+
+    const many = await proxyPorts(client, 'demo', [
+      { localPort: 0, remotePort: 3001 },
+      { localPort: 0, remotePort: 3002 },
+    ]);
+    assert.equal(many.length, 2);
+    many.forEach(session => session.close());
+
+    const sprite = new SpritesClient('token', { baseURL: 'https://example.test' }).sprite('demo');
+    const spriteSingle = await sprite.proxyPort(0, 4000);
+    const spriteMany = await sprite.proxyPorts([{ localPort: 0, remotePort: 4001 }]);
+    spriteSingle.close();
+    spriteMany.forEach(session => session.close());
+  });
+
+  it('manages groups of sessions', async () => {
+    const first = new ProxySession(client, 'demo', { localPort: 0, remotePort: 3000 });
+    const second = new ProxySession(client, 'demo', { localPort: 0, remotePort: 3001 });
+    await Promise.all([first.start(), second.start()]);
+    const manager = new ProxyManager();
+    manager.addSession(first);
+    manager.addSession(second);
+    manager.closeAll();
+    await manager.waitAll();
+  });
+});

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -60,7 +60,7 @@ export class ProxySession extends EventEmitter {
     if (baseURL.startsWith('http')) {
       baseURL = 'ws' + baseURL.substring(4);
     }
-    const wsURL = `${baseURL}/v1/sprites/${this.spriteName}/proxy`;
+    const wsURL = `${baseURL}/v1/sprites/${encodeURIComponent(this.spriteName)}/proxy`;
 
     try {
       const ws = new WebSocket(wsURL, {

--- a/src/public-api.test.ts
+++ b/src/public-api.test.ts
@@ -1,0 +1,326 @@
+import assert from 'node:assert/strict';
+import { afterEach, describe, it } from 'node:test';
+import * as api from './index.js';
+import { SpritesClient } from './client.js';
+import { ControlConnection, OpConn } from './control.js';
+import { SpriteCommand } from './exec.js';
+import { APIError, StreamID } from './types.js';
+
+const originalWebSocket = globalThis.WebSocket;
+const originalFetch = globalThis.fetch;
+
+type Listener = (event: any) => void;
+
+class MockWebSocket {
+  static readonly CONNECTING = 0;
+  static readonly OPEN = 1;
+  static readonly CLOSING = 2;
+  static readonly CLOSED = 3;
+  static instances: MockWebSocket[] = [];
+
+  readonly url: string;
+  readyState = MockWebSocket.CONNECTING;
+  binaryType = 'blob';
+  sent: unknown[] = [];
+  private listeners = new Map<string, Set<Listener>>();
+
+  constructor(url: string | URL) {
+    this.url = url.toString();
+    MockWebSocket.instances.push(this);
+    queueMicrotask(() => {
+      this.readyState = MockWebSocket.OPEN;
+      this.dispatch('open', {});
+    });
+  }
+
+  addEventListener(type: string, listener: Listener): void {
+    const listeners = this.listeners.get(type) ?? new Set();
+    listeners.add(listener);
+    this.listeners.set(type, listeners);
+  }
+
+  removeEventListener(type: string, listener: Listener): void {
+    this.listeners.get(type)?.delete(listener);
+  }
+
+  send(data: unknown): void {
+    this.sent.push(data);
+  }
+
+  close(code = 1000, reason = ''): void {
+    if (this.readyState === MockWebSocket.CLOSED) return;
+    this.readyState = MockWebSocket.CLOSED;
+    this.dispatch('close', { code, reason });
+  }
+
+  dispatch(type: string, event: unknown): void {
+    for (const listener of this.listeners.get(type) ?? []) listener(event);
+  }
+}
+
+function installWebSocket(): void {
+  MockWebSocket.instances = [];
+  globalThis.WebSocket = MockWebSocket as unknown as typeof WebSocket;
+}
+
+function binary(...bytes: number[]): ArrayBuffer {
+  return Uint8Array.from(bytes).buffer;
+}
+
+afterEach(() => {
+  globalThis.WebSocket = originalWebSocket;
+  globalThis.fetch = originalFetch;
+});
+
+describe('package exports', () => {
+  it('exports the complete supported runtime surface', () => {
+    assert.deepEqual(Object.keys(api).sort(), [
+      'APIError', 'CheckpointStream', 'ControlConnection',
+      'ERR_CODE_CONCURRENT_LIMIT_EXCEEDED', 'ERR_CODE_CREATION_RATE_LIMITED',
+      'ExecError', 'FilesystemError', 'FilesystemWatcher', 'OpConn', 'PortWatcher',
+      'ProxyManager', 'ProxySession', 'RestoreStream', 'ServiceLogStream', 'SessionKillStream', 'Sprite', 'SpriteCommand',
+      'SpriteFilesystem', 'SpriteListStream', 'SpritesClient', 'StreamID', 'parseAPIError',
+      'proxyPort', 'proxyPorts',
+    ]);
+  });
+});
+
+describe('SpriteCommand and Sprite execution interfaces', () => {
+  it('starts, streams, signals, resizes, reports exit, and waits', async () => {
+    installWebSocket();
+    const sprite = new SpritesClient('token', { baseURL: 'https://example.test' }).sprite('demo/name');
+    const command = new SpriteCommand(sprite, 'printf', ['hello'], { tty: false });
+    assert.ok(command.stdin.writable);
+    assert.ok(command.stdout.readable);
+    assert.ok(command.stderr.readable);
+    await command.start();
+    await assert.rejects(() => command.start(), /already started/);
+
+    const ws = MockWebSocket.instances[0];
+    const stdout: Buffer[] = [];
+    const stderr: Buffer[] = [];
+    command.stdout.on('data', chunk => stdout.push(chunk));
+    command.stderr.on('data', chunk => stderr.push(chunk));
+    command.stdin.write('input');
+    command.stdin.end();
+    command.signal('HUP');
+    command.kill();
+    command.resize(80, 24);
+    ws.dispatch('message', { data: binary(StreamID.Stdout, ...Buffer.from('out')) });
+    ws.dispatch('message', { data: binary(StreamID.Stderr, ...Buffer.from('err')) });
+    const waited = command.wait();
+    ws.dispatch('message', { data: binary(StreamID.Exit, 0) });
+    assert.equal(await waited, 0);
+    assert.equal(command.exitCode(), 0);
+    assert.equal(Buffer.concat(stdout).toString(), 'out');
+    assert.equal(Buffer.concat(stderr).toString(), 'err');
+    assert.match(ws.url, /sprites\/demo%2Fname\/exec/);
+    assert.ok(ws.sent.some(value => typeof value === 'string' && value.includes('signal')));
+  });
+
+  it('covers Sprite spawn, session, exec, and execFile convenience methods', async () => {
+    installWebSocket();
+    const sprite = new SpritesClient('token', { baseURL: 'https://example.test' }).sprite('demo');
+    const spawned = sprite.spawn('true');
+    const session = sprite.createSession('bash');
+    const attached = sprite.attachSession('session/id');
+    assert.ok(spawned instanceof SpriteCommand);
+    assert.ok(session instanceof SpriteCommand);
+    assert.ok(attached instanceof SpriteCommand);
+    await new Promise(resolve => setImmediate(resolve));
+    assert.match(MockWebSocket.instances[2].url, /exec\/session%2Fid/);
+    MockWebSocket.instances[2].dispatch('message', { data: '{"type":"session_info","tty":true}' });
+    await new Promise(resolve => setImmediate(resolve));
+    for (const ws of MockWebSocket.instances.slice(0, 3)) ws.close();
+
+    const execPromise = sprite.exec('echo hello');
+    await new Promise(resolve => setImmediate(resolve));
+    let ws = MockWebSocket.instances.at(-1)!;
+    ws.dispatch('message', { data: binary(StreamID.Stdout, ...Buffer.from('hello\n')) });
+    ws.dispatch('message', { data: binary(StreamID.Exit, 0) });
+    assert.equal((await execPromise).stdout, 'hello\n');
+
+    const filePromise = sprite.execFile('false', [], { encoding: 'buffer' as BufferEncoding });
+    await new Promise(resolve => setImmediate(resolve));
+    ws = MockWebSocket.instances.at(-1)!;
+    ws.dispatch('message', { data: binary(StreamID.Stderr, ...Buffer.from('failed')) });
+    ws.dispatch('message', { data: binary(StreamID.Exit, 2) });
+    await assert.rejects(filePromise, (error: any) => error.exitCode === 2 && Buffer.isBuffer(error.stderr));
+  });
+
+  it('executes over HTTP and streams session-kill progress', async () => {
+    const encoder = new TextEncoder();
+    const responses = [
+      new Response(new ReadableStream({ start(controller) {
+        controller.enqueue(Uint8Array.from([StreamID.Stdout, ...Buffer.from('out')]));
+        controller.enqueue(Uint8Array.from([StreamID.Stderr, ...Buffer.from('err')]));
+        controller.enqueue(Uint8Array.from([StreamID.Exit, 0]));
+        controller.close();
+      } })),
+      new Response(new ReadableStream({ start(controller) {
+        controller.enqueue(encoder.encode('{"type":"signal","message":"sent","signal":"SIGTERM","pid":2}\n'));
+        controller.enqueue(encoder.encode('{"type":"complete","exit_code":0}\n'));
+        controller.close();
+      } })),
+    ];
+    const calls: Array<{ url: string; init?: RequestInit }> = [];
+    globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
+      calls.push({ url: input.toString(), init });
+      return responses.shift()!;
+    }) as typeof fetch;
+    const sprite = new SpritesClient('token', { baseURL: 'https://example.test' }).sprite('demo/name');
+    const abort = new AbortController();
+    const result = await sprite.execFileHTTP('cat', [], {
+      input: 'hello', env: { MODE: 'test' }, cwd: '/app', signal: abort.signal, timeout: 60_000,
+    });
+    assert.deepEqual(result, { stdout: 'out', stderr: 'err', exitCode: 0 });
+    assert.equal(new URL(calls[0].url).searchParams.get('stdin'), 'true');
+    assert.deepEqual(Buffer.from(calls[0].init?.body as Buffer), Buffer.from('hello'));
+    assert.ok(calls[0].init?.signal instanceof AbortSignal);
+    const kill = await sprite.killSession('session/id', 'TERM', '5s');
+    assert.equal((await kill.next())?.pid, 2);
+    assert.equal((await kill.next())?.exitCode, 0);
+    assert.match(calls[1].url, /exec\/session%2Fid\/kill/);
+  });
+
+  it('rejects invalid HTTP frames and cancels the response stream on early failure', async () => {
+    let invalidFrameCancelled = false;
+    let maxBufferCancelled = false;
+    const responses = [
+      new Response(new ReadableStream({
+        start(controller) {
+          controller.enqueue(Uint8Array.from([0x7f, ...Buffer.from('continued output')]));
+        },
+        cancel() { invalidFrameCancelled = true; },
+      })),
+      new Response(new ReadableStream({
+        start(controller) {
+          controller.enqueue(Uint8Array.from([StreamID.Stdout, ...Buffer.from('too large')]));
+        },
+        cancel() { maxBufferCancelled = true; },
+      })),
+    ];
+    globalThis.fetch = (async () => responses.shift()!) as typeof fetch;
+    const sprite = new SpritesClient('token', { baseURL: 'https://example.test' }).sprite('demo');
+
+    await assert.rejects(
+      () => sprite.execFileHTTP('cat'),
+      /Unsupported HTTP exec frame type 0x7f/
+    );
+    assert.equal(invalidFrameCancelled, true);
+    await assert.rejects(
+      () => sprite.execFileHTTP('cat', [], { maxBuffer: 2 }),
+      /stdout maxBuffer exceeded/
+    );
+    assert.equal(maxBufferCancelled, true);
+    await assert.rejects(
+      () => sprite.execFileHTTP('cat', [], { timeout: -1 }),
+      /timeout must be a non-negative finite number/
+    );
+  });
+
+  it('uses structured API errors for session-kill failures', async () => {
+    globalThis.fetch = (async () => new Response(
+      JSON.stringify({ error: 'too many requests', error_code: 'concurrent_limit_exceeded' }),
+      { status: 429, headers: { 'content-type': 'application/json' } }
+    )) as typeof fetch;
+    const sprite = new SpritesClient('token', { baseURL: 'https://example.test' }).sprite('demo');
+    await assert.rejects(() => sprite.killSession('session'), APIError);
+  });
+
+  it('watches ports and filesystem events', async () => {
+    installWebSocket();
+    const sprite = new SpritesClient('token', { baseURL: 'https://example.test' }).sprite('demo/name');
+    const ports = await sprite.watchPorts();
+    let ws = MockWebSocket.instances[0];
+    ws.dispatch('message', { data: '{"type":"port_list","ports":[]}' });
+    assert.deepEqual(await ports.next(), { type: 'port_list', ports: [] });
+    const nextPort = ports.next();
+    ws.dispatch('error', { message: 'connection lost' });
+    await assert.rejects(nextPort, /connection lost/);
+    await assert.rejects(() => ports.next(), /connection lost/);
+    assert.equal(ports.isClosed(), true);
+
+    const watcher = await sprite.filesystem('/app').watch(['src', 'test'], { recursive: true });
+    ws = MockWebSocket.instances[1];
+    assert.deepEqual(JSON.parse(ws.sent[0] as string), {
+      type: 'subscribe', paths: ['src', 'test'], recursive: true, workingDir: '/app',
+    });
+    ws.dispatch('message', { data: '{"type":"event","path":"src/a.ts","event":"write","isDir":false}' });
+    assert.equal((await watcher.next())?.event, 'write');
+    const iteration = (async () => {
+      for await (const _event of watcher) {
+        // Wait for a terminal watcher error.
+        void _event;
+      }
+    })();
+    await new Promise(resolve => setImmediate(resolve));
+    ws.dispatch('error', { message: 'filesystem watch failed' });
+    await assert.rejects(iteration, /filesystem watch failed/);
+  });
+});
+
+describe('control interfaces', () => {
+  it('covers OpConn I/O, messages, completion, closing, and state', async () => {
+    const sent: Buffer[] = [];
+    const fakeConnection = {
+      sendData: (data: Buffer) => { sent.push(data); },
+    } as unknown as ControlConnection;
+    const op = new OpConn(fakeConnection, false);
+    const stdout: Buffer[] = [];
+    const stderr: Buffer[] = [];
+    const messages: unknown[] = [];
+    op.on('stdout', value => stdout.push(value));
+    op.on('stderr', value => stderr.push(value));
+    op.on('message', value => messages.push(value));
+    op.write(Buffer.from('in'));
+    op.sendEOF();
+    op.resize(80, 24);
+    op.signal('TERM');
+    op.handleData(Buffer.from([StreamID.Stdout, ...Buffer.from('out')]));
+    op.handleData(Buffer.from([StreamID.Stderr, ...Buffer.from('err')]));
+    op.handleData(Buffer.from([StreamID.Exit, 7]));
+    op.handleText('{"type":"port_opened","port":3000}');
+    const waited = op.wait();
+    op.complete();
+    assert.equal(await waited, 7);
+    assert.equal(op.getExitCode(), 7);
+    assert.equal(op.isClosed(), true);
+    assert.equal(Buffer.concat(stdout).toString(), 'out');
+    assert.equal(Buffer.concat(stderr).toString(), 'err');
+    assert.equal((messages[0] as any).port, 3000);
+    assert.equal(sent[0][0], StreamID.Stdin);
+    assert.equal(sent[1][0], StreamID.StdinEOF);
+    assert.throws(() => op.write(Buffer.from('late')), /Operation closed/);
+    op.close();
+  });
+
+  it('connects ControlConnection, starts operations, sends data, and closes', async () => {
+    installWebSocket();
+    const sprite = new SpritesClient('token', { baseURL: 'https://example.test' }).sprite('demo/name');
+    const connection = new ControlConnection(sprite);
+    assert.equal(connection.isActive(), false);
+    connection.setActive(true);
+    assert.equal(connection.isActive(), true);
+    await connection.connect();
+    await assert.rejects(() => connection.connect(), /Already connected/);
+    const op = await connection.startOp('exec', { cmd: ['echo'], env: ['A=1'], dir: '/app', tty: true, rows: 24, cols: 80, stdin: true });
+    const ws = MockWebSocket.instances[0];
+    assert.match(ws.url, /sprites\/demo%2Fname\/control$/);
+    assert.ok(String(ws.sent[0]).startsWith('control:'));
+    connection.sendData(Buffer.from('raw'));
+    const waited = op.wait();
+    ws.dispatch('message', { data: 'control:{"type":"op.complete","args":{"exitCode":4}}' });
+    assert.equal(await waited, 4);
+    connection.clearOpConn();
+    connection.close();
+    assert.equal(connection.isClosed(), true);
+    await assert.rejects(() => connection.startOp('exec'), /closed/);
+
+    const pooled = await sprite.getControlConnection();
+    assert.equal(sprite.hasControlConnection(), true);
+    assert.ok(pooled instanceof ControlConnection);
+    sprite.closeControlConnection();
+    assert.equal(sprite.hasControlConnection(), false);
+  });
+});

--- a/src/services.ts
+++ b/src/services.ts
@@ -46,7 +46,7 @@ export class ServiceLogStream {
         }
 
         try {
-          return JSON.parse(line) as ServiceLogEvent;
+          return this.parseEvent(line);
         } catch {
           // Skip malformed JSON lines
           continue;
@@ -65,7 +65,7 @@ export class ServiceLogStream {
         // Process any remaining buffer content
         if (this.buffer.trim()) {
           try {
-            return JSON.parse(this.buffer.trim()) as ServiceLogEvent;
+            return this.parseEvent(this.buffer.trim());
           } catch {
             return null;
           }
@@ -118,11 +118,58 @@ export class ServiceLogStream {
       this.close();
     }
   }
+
+  private parseEvent(line: string): ServiceLogEvent {
+    const data = JSON.parse(line);
+    return {
+      type: data.type,
+      data: data.data,
+      exitCode: data.exit_code,
+      timestamp: data.timestamp,
+      logFiles: data.log_files,
+    };
+  }
 }
 
 interface ClientInfo {
   baseURL: string;
   token: string;
+}
+
+function servicesURL(client: ClientInfo, spriteName: string, suffix = ''): string {
+  return `${client.baseURL}/v1/sprites/${encodeURIComponent(spriteName)}/services${suffix}`;
+}
+
+function serviceFromAPI(data: any): ServiceWithState {
+  return {
+    name: data.name,
+    cmd: data.cmd,
+    args: data.args ?? [],
+    env: data.env,
+    dir: data.dir,
+    needs: data.needs ?? [],
+    httpPort: data.http_port,
+    state: data.state ? {
+      name: data.state.name,
+      status: data.state.status,
+      pid: data.state.pid,
+      startedAt: data.state.started_at,
+      error: data.state.error,
+      restartCount: data.state.restart_count,
+      nextRestartAt: data.state.next_restart_at,
+    } : undefined,
+  };
+}
+
+function serviceRequestToAPI(config: ServiceRequest): Record<string, unknown> {
+  return {
+    cmd: config.cmd,
+    ...(config.args !== undefined && { args: config.args }),
+    ...(config.env !== undefined && { env: config.env }),
+    ...(config.dir !== undefined && { dir: config.dir }),
+    ...(config.needs !== undefined && { needs: config.needs }),
+    ...(config.httpPort !== undefined && { http_port: config.httpPort }),
+  };
 }
 
 /**
@@ -133,7 +180,7 @@ export async function listServices(
   spriteName: string
 ): Promise<ServiceWithState[]> {
   const response = await fetch(
-    `${client.baseURL}/v1/sprites/${spriteName}/services`,
+    servicesURL(client, spriteName),
     {
       method: 'GET',
       headers: {
@@ -150,7 +197,9 @@ export async function listServices(
     );
   }
 
-  return (await response.json()) as ServiceWithState[];
+  const data = await response.json() as any;
+  const services = Array.isArray(data) ? data : data.services ?? [];
+  return services.map(serviceFromAPI);
 }
 
 /**
@@ -162,7 +211,7 @@ export async function getService(
   serviceName: string
 ): Promise<ServiceWithState> {
   const response = await fetch(
-    `${client.baseURL}/v1/sprites/${spriteName}/services/${serviceName}`,
+    servicesURL(client, spriteName, `/${encodeURIComponent(serviceName)}`),
     {
       method: 'GET',
       headers: {
@@ -184,7 +233,7 @@ export async function getService(
     );
   }
 
-  return (await response.json()) as ServiceWithState;
+  return serviceFromAPI(await response.json());
 }
 
 /**
@@ -198,7 +247,7 @@ export async function createService(
   config: ServiceRequest,
   duration?: string
 ): Promise<ServiceLogStream> {
-  let url = `${client.baseURL}/v1/sprites/${spriteName}/services/${serviceName}`;
+  let url = servicesURL(client, spriteName, `/${encodeURIComponent(serviceName)}`);
   if (duration) {
     url += `?duration=${duration}`;
   }
@@ -209,7 +258,7 @@ export async function createService(
       Authorization: `Bearer ${client.token}`,
       'Content-Type': 'application/json',
     },
-    body: JSON.stringify(config),
+    body: JSON.stringify(serviceRequestToAPI(config)),
   });
 
   if (response.status === 409) {
@@ -236,7 +285,7 @@ export async function deleteService(
   serviceName: string
 ): Promise<void> {
   const response = await fetch(
-    `${client.baseURL}/v1/sprites/${spriteName}/services/${serviceName}`,
+    servicesURL(client, spriteName, `/${encodeURIComponent(serviceName)}`),
     {
       method: 'DELETE',
       headers: {
@@ -274,7 +323,7 @@ export async function startService(
   serviceName: string,
   duration?: string
 ): Promise<ServiceLogStream> {
-  let url = `${client.baseURL}/v1/sprites/${spriteName}/services/${serviceName}/start`;
+  let url = servicesURL(client, spriteName, `/${encodeURIComponent(serviceName)}/start`);
   if (duration) {
     url += `?duration=${duration}`;
   }
@@ -311,7 +360,7 @@ export async function stopService(
   serviceName: string,
   timeout?: string
 ): Promise<ServiceLogStream> {
-  let url = `${client.baseURL}/v1/sprites/${spriteName}/services/${serviceName}/stop`;
+  let url = servicesURL(client, spriteName, `/${encodeURIComponent(serviceName)}/stop`);
   if (timeout) {
     url += `?timeout=${timeout}`;
   }
@@ -343,6 +392,47 @@ export async function stopService(
   return new ServiceLogStream(response);
 }
 
+/** Restart a service and stream stop/start progress. */
+export async function restartService(
+  client: ClientInfo,
+  spriteName: string,
+  serviceName: string,
+  duration?: string
+): Promise<ServiceLogStream> {
+  const url = new URL(servicesURL(client, spriteName, `/${encodeURIComponent(serviceName)}/restart`));
+  if (duration) url.searchParams.set('duration', duration);
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${client.token}` },
+  });
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(`Failed to restart service (status ${response.status}): ${body}`);
+  }
+  return new ServiceLogStream(response);
+}
+
+/** Read buffered service logs and optionally follow new output. */
+export async function getServiceLogs(
+  client: ClientInfo,
+  spriteName: string,
+  serviceName: string,
+  options: { lines?: number; duration?: string } = {}
+): Promise<ServiceLogStream> {
+  const url = new URL(servicesURL(client, spriteName, `/${encodeURIComponent(serviceName)}/logs`));
+  if (options.lines !== undefined) url.searchParams.set('lines', options.lines.toString());
+  if (options.duration) url.searchParams.set('duration', options.duration);
+  const response = await fetch(url, {
+    method: 'GET',
+    headers: { Authorization: `Bearer ${client.token}` },
+  });
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(`Failed to get service logs (status ${response.status}): ${body}`);
+  }
+  return new ServiceLogStream(response);
+}
+
 /**
  * Send a signal to a service
  */
@@ -353,7 +443,7 @@ export async function signalService(
   signal: string
 ): Promise<void> {
   const response = await fetch(
-    `${client.baseURL}/v1/sprites/${spriteName}/services/signal`,
+    servicesURL(client, spriteName, '/signal'),
     {
       method: 'POST',
       headers: {

--- a/src/sprite.test.ts
+++ b/src/sprite.test.ts
@@ -1,0 +1,134 @@
+import assert from 'node:assert/strict';
+import { afterEach, describe, it } from 'node:test';
+import { SpritesClient } from './client.js';
+import { Sprite } from './sprite.js';
+import { SpriteFilesystem } from './filesystem.js';
+
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+function json(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), { status, headers: { 'content-type': 'application/json' } });
+}
+
+describe('Sprite public interface', () => {
+  it('delegates lifecycle and update operations to its client', async () => {
+    const client = new SpritesClient('token');
+    const sprite = new Sprite('demo', client);
+    const calls: unknown[][] = [];
+    client.deleteSprite = async (...args) => { calls.push(['delete', ...args]); };
+    client.upgradeSprite = async (...args) => { calls.push(['upgrade', ...args]); };
+    client.restartSprite = async (...args) => {
+      calls.push(['restart', ...args]);
+      return { spriteName: 'demo', machineId: 'm1', message: 'queued' };
+    };
+    client.checkSprite = async (...args) => {
+      calls.push(['check', ...args]);
+      return { spriteName: 'demo', spriteId: 's1', status: 'ok', checkedAt: new Date(0) };
+    };
+    client.updateURLSettings = async (...args) => { calls.push(['url', ...args]); };
+    client.updateSprite = async (...args) => { calls.push(['update', ...args]); return sprite; };
+
+    await sprite.delete();
+    await sprite.destroy();
+    await sprite.upgrade();
+    assert.equal((await sprite.restart()).machineId, 'm1');
+    assert.equal((await sprite.check()).status, 'ok');
+    await sprite.updateURLSettings({ auth: 'public' });
+    assert.equal(await sprite.update({ labels: ['test'] }), sprite);
+    assert.deepEqual(calls.map(call => call[0]), ['delete', 'delete', 'upgrade', 'restart', 'check', 'url', 'update']);
+  });
+
+  it('lists sessions and supports every checkpoint operation', async () => {
+    const calls: Array<{ url: string; init?: RequestInit }> = [];
+    const responses = [
+      json({ sessions: [{ id: 'session-1', command: 'bash', workdir: '/app', created: '2026-07-20T10:00:00Z', bytes_per_second: 12.5, is_active: true, last_activity: '2026-07-20T10:01:00Z', tty: true }] }),
+      new Response('{"type":"info","data":"saving"}\n'),
+      json([{ id: 'v1', create_time: '2026-07-20T10:00:00Z', comment: 'first', history: ['Current'], is_auto: true }]),
+      json({ id: 'v1', create_time: '2026-07-20T10:00:00Z', comment: 'first', history: [], is_auto: true }),
+      new Response('{"type":"info","data":"restoring"}\n'),
+    ];
+    globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
+      calls.push({ url: input.toString(), init });
+      return responses.shift()!;
+    }) as typeof fetch;
+
+    const sprite = new SpritesClient('token', { baseURL: 'https://example.test' }).sprite('demo/name');
+    const sessions = await sprite.listSessions();
+    assert.equal(sessions[0].lastActivity?.toISOString(), '2026-07-20T10:01:00.000Z');
+
+    const create = await sprite.createCheckpoint('before deploy');
+    assert.deepEqual(await create.next(), { type: 'info', data: 'saving' });
+    const checkpoints = await sprite.listCheckpoints('all/history');
+    assert.equal(checkpoints[0].isAuto, true);
+    assert.equal(new URL(calls[2].url).searchParams.get('history'), 'all/history');
+    assert.equal((await sprite.getCheckpoint('v/1')).isAuto, true);
+    const restore = await sprite.restoreCheckpoint('v/1');
+    assert.equal((await restore.next())?.data, 'restoring');
+    assert.ok(calls.every(call => call.url.includes('demo%2Fname')));
+    assert.match(calls[3].url, /checkpoints\/v%2F1$/);
+  });
+
+  it('exposes services, policies, filesystem, and control-mode state', async () => {
+    const calls: Array<{ url: string; init?: RequestInit }> = [];
+    globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
+      const url = input.toString();
+      calls.push({ url, init });
+      if (url.endsWith('/services') && init?.method === 'GET') {
+        return json({ services: [{ name: 'web api', cmd: 'node', args: [], needs: [], http_port: 3000, state: { name: 'web api', status: 'running', restart_count: 2 } }] });
+      }
+      if (new URL(url).pathname.endsWith('/services/web%20api') && init?.method === 'GET') {
+        return json({ name: 'web api', cmd: 'node', args: [], needs: [], http_port: 3000 });
+      }
+      if (new URL(url).pathname.endsWith('/services/web%20api') && init?.method === 'PUT') {
+        return new Response('{"type":"started","timestamp":1,"log_files":{"stdout":"/tmp/out"}}\n');
+      }
+      if (url.includes('/services/web%20api/start')) return new Response('{"type":"started","timestamp":2}\n');
+      if (url.includes('/services/web%20api/stop')) return new Response('{"type":"stopped","timestamp":3,"exit_code":0}\n');
+      if (url.includes('/services/web%20api/restart')) return new Response('{"type":"started","timestamp":4}\n');
+      if (url.includes('/services/web%20api/logs')) return new Response('{"type":"stdout","data":"log","timestamp":5}\n');
+      if (url.includes('/services/signal')) return new Response(null, { status: 204 });
+      if (new URL(url).pathname.endsWith('/services/web%20api') && init?.method === 'DELETE') return new Response(null, { status: 204 });
+      if (url.endsWith('/policy/network') && init?.method === 'GET') return json({ rules: [{ action: 'allow', domain: 'example.com' }] });
+      if (url.endsWith('/policy/network') && init?.method === 'POST') return new Response(null, { status: 204 });
+      if (url.endsWith('/policy/privileges') && init?.method === 'GET') return json({ profile: 'standard', devices: ['null'], noNewPrivileges: true });
+      if (url.endsWith('/policy/privileges')) return new Response(null, { status: 204 });
+      if (url.endsWith('/policy/resources') && init?.method === 'GET') return json({ memory: { limit_mb: 512, autoscale: true } });
+      if (url.endsWith('/policy/resources')) return new Response(null, { status: 204 });
+      throw new Error(`Unexpected request: ${init?.method} ${url}`);
+    }) as typeof fetch;
+
+    const client = new SpritesClient('token', { baseURL: 'https://example.test', controlMode: true });
+    const sprite = client.sprite('demo/name');
+    const services = await sprite.listServices();
+    assert.equal(services[0].httpPort, 3000);
+    assert.equal(services[0].state?.restartCount, 2);
+    assert.equal((await sprite.getService('web api')).name, 'web api');
+    const created = await sprite.createService('web api', { cmd: 'node', env: { MODE: 'test' }, dir: '/app', httpPort: 3000 }, '5s');
+    assert.deepEqual(await created.next(), { type: 'started', data: undefined, exitCode: undefined, timestamp: 1, logFiles: { stdout: '/tmp/out' } });
+    const createCall = calls.find(call => call.init?.method === 'PUT')!;
+    assert.deepEqual(JSON.parse(createCall.init?.body as string), { cmd: 'node', env: { MODE: 'test' }, dir: '/app', http_port: 3000 });
+    assert.equal((await (await sprite.startService('web api', '5s')).next())?.type, 'started');
+    assert.equal((await (await sprite.stopService('web api', '10s')).next())?.exitCode, 0);
+    assert.equal((await (await sprite.restartService('web api', '5s')).next())?.type, 'started');
+    assert.equal((await (await sprite.getServiceLogs('web api', { lines: 10, duration: '1s' })).next())?.data, 'log');
+    await sprite.signalService('web api', 'TERM');
+    await sprite.deleteService('web api');
+    assert.equal((await sprite.getNetworkPolicy()).rules[0].domain, 'example.com');
+    await sprite.updateNetworkPolicy({ rules: [{ include: 'defaults' }] });
+    assert.equal((await sprite.getPrivilegesPolicy()).profile, 'standard');
+    await sprite.updatePrivilegesPolicy({ profile: 'minimal', noNewPrivileges: true });
+    await sprite.deletePrivilegesPolicy();
+    assert.equal((await sprite.getResourcesPolicy()).memory?.limitMB, 512);
+    await sprite.updateResourcesPolicy({ memory: { limitMB: 1024, autoscale: false } });
+    await sprite.deleteResourcesPolicy();
+
+    assert.ok(sprite.filesystem('/app') instanceof SpriteFilesystem);
+    assert.equal(sprite.useControlMode(), true);
+    assert.equal(sprite.hasControlConnection(), false);
+    sprite.closeControlConnection();
+  });
+});

--- a/src/sprite.ts
+++ b/src/sprite.ts
@@ -3,7 +3,7 @@
  */
 
 import { SpritesClient } from './client.js';
-import { SpriteCommand, spawn, exec, execFile } from './exec.js';
+import { SpriteCommand, SessionKillStream, spawn, exec, execFile, execFileHTTP, killSession } from './exec.js';
 import { CheckpointStream, RestoreStream } from './checkpoint.js';
 import { ProxySession, proxyPort, proxyPorts } from './proxy.js';
 import {
@@ -14,9 +14,20 @@ import {
   deleteService,
   startService,
   stopService,
+  restartService,
+  getServiceLogs,
   signalService,
 } from './services.js';
-import { getNetworkPolicy, updateNetworkPolicy } from './policy.js';
+import {
+  getNetworkPolicy,
+  updateNetworkPolicy,
+  getPrivilegesPolicy,
+  updatePrivilegesPolicy,
+  deletePrivilegesPolicy,
+  getResourcesPolicy,
+  updateResourcesPolicy,
+  deleteResourcesPolicy,
+} from './policy.js';
 import { SpriteFilesystem } from './filesystem.js';
 import { ControlConnection, getControlConnection, closeControlConnection, hasControlConnection } from './control.js';
 import type {
@@ -31,7 +42,14 @@ import type {
   ServiceWithState,
   ServiceRequest,
   NetworkPolicy,
+  UpdateSpriteOptions,
+  RestartSpriteResult,
+  SpriteCheck,
+  HTTPExecOptions,
+  PrivilegesPolicy,
+  ResourcesPolicy,
 } from './types.js';
+import { PortWatcher } from './watch.js';
 
 /**
  * Represents a sprite instance
@@ -51,6 +69,13 @@ export class Sprite {
   updatedAt?: Date;
   url?: string;
   urlSettings?: URLSettings;
+  bucketName?: string;
+  primaryRegion?: string;
+  version?: string;
+  environmentVersion?: string;
+  labels: string[] = [];
+  lastRunningAt?: Date;
+  lastWarmingAt?: Date;
 
   constructor(name: string, client: SpritesClient) {
     this.name = name;
@@ -76,6 +101,11 @@ export class Sprite {
    */
   async execFile(file: string, args: string[] = [], options: ExecOptions = {}): Promise<ExecResult> {
     return execFile(this, file, args, options);
+  }
+
+  /** Execute a non-TTY command over HTTP without a WebSocket. */
+  async execFileHTTP(file: string, args: string[] = [], options: HTTPExecOptions = {}): Promise<ExecResult> {
+    return execFileHTTP(this, file, args, options);
   }
 
   /**
@@ -104,7 +134,7 @@ export class Sprite {
    * List active sessions
    */
   async listSessions(): Promise<Session[]> {
-    const response = await fetch(`${this.client.baseURL}/v1/sprites/${this.name}/exec`, {
+    const response = await fetch(`${this.baseURL()}/exec`, {
       method: 'GET',
       headers: {
         'Authorization': `Bearer ${this.client.token}`,
@@ -143,6 +173,18 @@ export class Sprite {
     return sessions;
   }
 
+  /** Kill an active session and stream progress. */
+  async killSession(sessionId: string, signal?: string, timeout?: string): Promise<SessionKillStream> {
+    return killSession(this, sessionId, signal, timeout);
+  }
+
+  /** Watch listening ports and future port changes. */
+  async watchPorts(): Promise<PortWatcher> {
+    const watcher = new PortWatcher(this.client, this.name);
+    await watcher.connect();
+    return watcher;
+  }
+
   /**
    * Delete this sprite
    */
@@ -164,6 +206,16 @@ export class Sprite {
     await this.client.upgradeSprite(this.name);
   }
 
+  /** Restart the machine backing this Sprite. */
+  async restart(): Promise<RestartSpriteResult> {
+    return this.client.restartSprite(this.name);
+  }
+
+  /** Check this Sprite's current health. */
+  async check(): Promise<SpriteCheck> {
+    return this.client.checkSprite(this.name);
+  }
+
   /**
    * Create a checkpoint with an optional comment.
    * Returns a CheckpointStream for reading progress messages.
@@ -171,7 +223,7 @@ export class Sprite {
   async createCheckpoint(comment?: string): Promise<CheckpointStream> {
     const body: any = {};
     if (comment) body.comment = comment;
-    const response = await fetch(`${this.client.baseURL}/v1/sprites/${this.name}/checkpoint`, {
+    const response = await fetch(`${this.baseURL()}/checkpoint`, {
       method: 'POST',
       headers: {
         'Authorization': `Bearer ${this.client.token}`,
@@ -192,7 +244,7 @@ export class Sprite {
    * @param historyFilter - Optional filter for checkpoint history
    */
   async listCheckpoints(historyFilter?: string): Promise<Checkpoint[]> {
-    let url = `${this.client.baseURL}/v1/sprites/${this.name}/checkpoints`;
+    let url = `${this.baseURL()}/checkpoints`;
     if (historyFilter) {
       url += `?history=${encodeURIComponent(historyFilter)}`;
     }
@@ -213,6 +265,9 @@ export class Sprite {
       createTime: new Date(cp.create_time),
       comment: cp.comment,
       history: cp.history,
+      isAuto: cp.is_auto,
+      sourceId: cp.source_id,
+      health: cp.health,
     }));
   }
 
@@ -220,7 +275,7 @@ export class Sprite {
    * Get checkpoint details
    */
   async getCheckpoint(id: string): Promise<Checkpoint> {
-    const response = await fetch(`${this.client.baseURL}/v1/sprites/${this.name}/checkpoints/${id}`, {
+    const response = await fetch(`${this.baseURL()}/checkpoints/${encodeURIComponent(id)}`, {
       method: 'GET',
       headers: {
         'Authorization': `Bearer ${this.client.token}`,
@@ -240,6 +295,9 @@ export class Sprite {
       createTime: new Date(cp.create_time),
       comment: cp.comment,
       history: cp.history,
+      isAuto: cp.is_auto,
+      sourceId: cp.source_id,
+      health: cp.health,
     };
   }
 
@@ -248,7 +306,7 @@ export class Sprite {
    * Returns a RestoreStream for reading progress messages.
    */
   async restoreCheckpoint(id: string): Promise<RestoreStream> {
-    const response = await fetch(`${this.client.baseURL}/v1/sprites/${this.name}/checkpoints/${id}/restore`, {
+    const response = await fetch(`${this.baseURL()}/checkpoints/${encodeURIComponent(id)}/restore`, {
       method: 'POST',
       headers: {
         'Authorization': `Bearer ${this.client.token}`,
@@ -268,6 +326,11 @@ export class Sprite {
    */
   async updateURLSettings(settings: URLSettings): Promise<void> {
     await this.client.updateURLSettings(this.name, settings);
+  }
+
+  /** Partially update mutable settings and return the refreshed Sprite. */
+  async update(options: UpdateSpriteOptions): Promise<Sprite> {
+    return this.client.updateSprite(this.name, options);
   }
 
   /**
@@ -356,6 +419,17 @@ export class Sprite {
     return stopService(this.client, this.name, serviceName, timeout);
   }
 
+  async restartService(serviceName: string, duration?: string): Promise<ServiceLogStream> {
+    return restartService(this.client, this.name, serviceName, duration);
+  }
+
+  async getServiceLogs(
+    serviceName: string,
+    options: { lines?: number; duration?: string } = {}
+  ): Promise<ServiceLogStream> {
+    return getServiceLogs(this.client, this.name, serviceName, options);
+  }
+
   /**
    * Send a signal to a service
    * @param serviceName - Service to signal
@@ -379,6 +453,30 @@ export class Sprite {
    */
   async updateNetworkPolicy(policy: NetworkPolicy): Promise<void> {
     return updateNetworkPolicy(this.client, this.name, policy);
+  }
+
+  async getPrivilegesPolicy(): Promise<PrivilegesPolicy> {
+    return getPrivilegesPolicy(this.client, this.name);
+  }
+
+  async updatePrivilegesPolicy(policy: PrivilegesPolicy): Promise<void> {
+    return updatePrivilegesPolicy(this.client, this.name, policy);
+  }
+
+  async deletePrivilegesPolicy(): Promise<void> {
+    return deletePrivilegesPolicy(this.client, this.name);
+  }
+
+  async getResourcesPolicy(): Promise<ResourcesPolicy> {
+    return getResourcesPolicy(this.client, this.name);
+  }
+
+  async updateResourcesPolicy(policy: ResourcesPolicy): Promise<void> {
+    return updateResourcesPolicy(this.client, this.name, policy);
+  }
+
+  async deleteResourcesPolicy(): Promise<void> {
+    return deleteResourcesPolicy(this.client, this.name);
   }
 
   // ========== Filesystem API ==========
@@ -435,5 +533,8 @@ export class Sprite {
   hasControlConnection(): boolean {
     return hasControlConnection(this);
   }
-}
 
+  private baseURL(): string {
+    return `${this.client.baseURL}/v1/sprites/${encodeURIComponent(this.name)}`;
+  }
+}

--- a/src/streams.test.ts
+++ b/src/streams.test.ts
@@ -1,0 +1,64 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { CheckpointStream, RestoreStream } from './checkpoint.js';
+import { ServiceLogStream } from './services.js';
+
+function streamResponse(chunks: string[]): Response {
+  const encoder = new TextEncoder();
+  return new Response(new ReadableStream({
+    start(controller) {
+      for (const chunk of chunks) controller.enqueue(encoder.encode(chunk));
+      controller.close();
+    },
+  }));
+}
+
+describe('checkpoint and restore streams', () => {
+  for (const [name, Stream] of [['CheckpointStream', CheckpointStream], ['RestoreStream', RestoreStream]] as const) {
+    it(`${name} reads chunked NDJSON, skips malformed lines, and iterates`, async () => {
+      const stream = new Stream(streamResponse(['bad\n{"type":"info",', '"data":"one"}\n\n{"type":"error","error":"two"}']));
+      assert.deepEqual(await stream.next(), { type: 'info', data: 'one' });
+      const rest = [];
+      for await (const message of stream) rest.push(message);
+      assert.deepEqual(rest, [{ type: 'error', error: 'two' }]);
+      assert.equal(await stream.next(), null);
+    });
+
+    it(`${name} processes all messages and can be closed`, async () => {
+      const stream = new Stream(streamResponse(['{"type":"info","data":"one"}\n{"type":"info","data":"two"}\n']));
+      const messages: string[] = [];
+      await stream.processAll(message => { messages.push(message.data!); });
+      assert.deepEqual(messages, ['one', 'two']);
+      stream.close();
+      assert.equal(await stream.next(), null);
+    });
+
+    it(`${name} rejects responses without a body`, () => {
+      assert.throws(() => new Stream(new Response(null)), /Response has no body/);
+    });
+  }
+});
+
+describe('ServiceLogStream', () => {
+  it('maps snake_case events through next, processAll, and async iteration', async () => {
+    const stream = new ServiceLogStream(streamResponse([
+      'malformed\n{"type":"stdout","data":"one","timestamp":1}\n',
+      '{"type":"exit","exit_code":3,"timestamp":2,"log_files":{"stderr":"err.log"}}',
+    ]));
+    assert.equal((await stream.next())?.data, 'one');
+    const events = [];
+    for await (const event of stream) events.push(event);
+    assert.equal(events[0].exitCode, 3);
+    assert.deepEqual(events[0].logFiles, { stderr: 'err.log' });
+
+    const processed: string[] = [];
+    const second = new ServiceLogStream(streamResponse(['{"type":"stopped","timestamp":3}\n']));
+    await second.processAll(event => { processed.push(event.type); });
+    assert.deepEqual(processed, ['stopped']);
+    second.close();
+  });
+
+  it('rejects responses without a body', () => {
+    assert.throws(() => new ServiceLogStream(new Response(null)), /Response has no body/);
+  });
+});

--- a/src/types.ts
+++ b/src/types.ts
@@ -20,6 +20,8 @@ export interface ClientOptions {
 export interface URLSettings {
   /** Auth mode: "public" for no auth, "sprite" for Sprite authentication */
   auth?: string;
+  /** Who may use private Sprite authentication (for example, "admins") */
+  privateAccess?: 'admins' | 'org_users';
 }
 
 /**
@@ -56,6 +58,8 @@ export interface SpawnOptions {
   sessionId?: string;
   /** Enable control mode (requires detachable or sessionId) */
   controlMode?: boolean;
+  /** How long the command may keep running after disconnect (for example, "30s") */
+  maxRunAfterDisconnect?: string;
 }
 
 /**
@@ -104,6 +108,20 @@ export interface SpriteInfo {
   url?: string;
   /** URL authentication settings */
   urlSettings?: URLSettings;
+  /** Storage bucket name, when returned by the API */
+  bucketName?: string;
+  /** Primary deployment region, when returned by the API */
+  primaryRegion?: string;
+  /** Running Sprite runtime version */
+  version?: string;
+  /** Base environment image version */
+  environmentVersion?: string;
+  /** Labels attached to the Sprite */
+  labels?: string[];
+  /** Most recent transition to the running state */
+  lastRunningAt?: Date;
+  /** Most recent transition to the warm state */
+  lastWarmingAt?: Date;
 }
 
 /**
@@ -116,6 +134,8 @@ export interface ListOptions {
   maxResults?: number;
   /** Continuation token for pagination */
   continuationToken?: string;
+  /** Return minimal entries optimized for bulk loading */
+  bulkLoad?: boolean;
 }
 
 /**
@@ -128,6 +148,37 @@ export interface SpriteList {
   hasMore: boolean;
   /** Token for fetching next page */
   nextContinuationToken?: string;
+  /** Number of running Sprites in this result */
+  running?: number;
+  /** Number of warm Sprites in this result */
+  warm?: number;
+  /** Number of cold Sprites in this result */
+  cold?: number;
+  /** Organization name associated with the access token */
+  organizationName?: string;
+  /** Maximum number of running Sprites */
+  runningLimit?: number;
+  /** Maximum number of warm Sprites */
+  warmLimit?: number;
+}
+
+/** A state update from the streaming Sprite list endpoint. */
+export interface SpriteStateEvent {
+  type?: 'heartbeat';
+  name?: string;
+  status?: string;
+  runningVersion?: string;
+  lastRunningAt?: Date;
+  lastWarmingAt?: Date;
+  timestamp?: Date;
+  organization: {
+    name?: string;
+    running: number;
+    warm: number;
+    cold: number;
+    runningLimit?: number;
+    warmLimit?: number;
+  };
 }
 
 /**
@@ -165,6 +216,14 @@ export interface PortNotification {
   /** Process ID */
   pid: number;
 }
+
+/** Initial snapshot emitted by a port watcher. */
+export interface PortList {
+  type: 'port_list';
+  ports: PortNotification[];
+}
+
+export type PortWatchEvent = PortList | PortNotification;
 
 /**
  * Organization information
@@ -446,6 +505,69 @@ export interface CreateSpriteRequest {
   config?: SpriteConfig;
   /** Optional environment variables */
   environment?: Record<string, string>;
+  /** URL access settings */
+  urlSettings?: URLSettings;
+  /** Labels to attach */
+  labels?: string[];
+  /** Wait for capacity instead of failing immediately */
+  waitForCapacity?: boolean;
+  /** Runtime image variant */
+  runtime?: 'default' | 'dev';
+}
+
+/** Options accepted when creating a Sprite. */
+export interface CreateSpriteOptions {
+  config?: SpriteConfig;
+  environment?: Record<string, string>;
+  urlSettings?: URLSettings;
+  labels?: string[];
+  waitForCapacity?: boolean;
+  runtime?: 'default' | 'dev';
+}
+
+/** Mutable Sprite fields. Omitted fields are left unchanged. */
+export interface UpdateSpriteOptions {
+  urlSettings?: URLSettings;
+  labels?: string[];
+}
+
+/** Response returned after requesting a Sprite restart. */
+export interface RestartSpriteResult {
+  spriteName: string;
+  machineId: string;
+  message: string;
+}
+
+/** Options for HTTP command execution without WebSockets. */
+export interface HTTPExecOptions extends Omit<
+  ExecOptions,
+  'tty' | 'sessionId' | 'controlMode' | 'detachable' | 'maxRunAfterDisconnect'
+> {
+  /** Bytes forwarded to stdin. Supplying this enables stdin. */
+  input?: string | Buffer;
+  /** Abort the HTTP request. */
+  signal?: AbortSignal;
+  /** Abort the HTTP request after this many milliseconds. */
+  timeout?: number;
+}
+
+/** Progress event returned while killing an exec session. */
+export interface SessionKillEvent {
+  type: 'signal' | 'timeout' | 'exited' | 'killed' | 'error' | 'complete';
+  message?: string;
+  signal?: string;
+  pid?: number;
+  exitCode?: number;
+}
+
+/** Current Sprite health information. */
+export interface SpriteCheck {
+  spriteName: string;
+  spriteId: string;
+  status: string;
+  reason?: string;
+  checkedAt: Date;
+  elapsed?: number;
 }
 
 /**
@@ -460,6 +582,12 @@ export interface Checkpoint {
   comment?: string;
   /** Optional history entries */
   history?: string[];
+  /** Whether the checkpoint was created automatically */
+  isAuto?: boolean;
+  /** Parent checkpoint identifier */
+  sourceId?: string;
+  /** Empty when healthy, otherwise an API health marker */
+  health?: string;
 }
 
 /**
@@ -516,6 +644,10 @@ export interface Service {
   cmd: string;
   /** Command arguments */
   args: string[];
+  /** Environment variables added to the base service environment */
+  env?: Record<string, string>;
+  /** Working directory */
+  dir?: string;
   /** Service dependencies */
   needs: string[];
   /** Optional HTTP port for proxy routing */
@@ -558,6 +690,10 @@ export interface ServiceRequest {
   cmd: string;
   /** Command arguments */
   args?: string[];
+  /** Environment variables added to the base service environment */
+  env?: Record<string, string>;
+  /** Working directory */
+  dir?: string;
   /** Service dependencies */
   needs?: string[];
   /** Optional HTTP port for proxy routing */
@@ -598,6 +734,21 @@ export interface PolicyRule {
 export interface NetworkPolicy {
   /** Array of policy rules */
   rules: PolicyRule[];
+}
+
+/** Process privilege restrictions. */
+export interface PrivilegesPolicy {
+  profile?: '' | 'minimal' | 'standard' | 'privileged';
+  devices?: string[];
+  noNewPrivileges?: boolean;
+}
+
+/** Memory resource policy. */
+export interface ResourcesPolicy {
+  memory?: {
+    limitMB: number;
+    autoscale?: boolean;
+  };
 }
 
 // ========== Filesystem Types ==========
@@ -649,6 +800,7 @@ export type FilesystemErrorCode =
   | 'ENOTDIR'   // Not a directory
   | 'EISDIR'    // Is a directory
   | 'EACCES'    // Permission denied
+  | 'EPERM'     // Operation not permitted
   | 'ENOTEMPTY' // Directory not empty
   | 'EINVAL'    // Invalid argument
   | 'EIO'       // I/O error
@@ -677,6 +829,10 @@ export interface ReaddirOptions {
   withFileTypes?: boolean;
   /** Encoding for file names (default: 'utf8') */
   encoding?: BufferEncoding;
+  /** Recursively list matching entries */
+  recursive?: boolean;
+  /** Optional glob pattern */
+  pattern?: string;
 }
 
 /**
@@ -697,6 +853,8 @@ export interface RmOptions {
   force?: boolean;
   /** Recursively remove directory contents */
   recursive?: boolean;
+  /** Perform the operation as root */
+  asRoot?: boolean;
 }
 
 /**
@@ -705,6 +863,10 @@ export interface RmOptions {
 export interface CopyFileOptions {
   /** Recursively copy directory contents */
   recursive?: boolean;
+  /** Preserve ownership and mode */
+  preserveAttrs?: boolean;
+  /** Perform the operation as root */
+  asRoot?: boolean;
 }
 
 /**
@@ -713,6 +875,36 @@ export interface CopyFileOptions {
 export interface ChmodOptions {
   /** Recursively change mode */
   recursive?: boolean;
+  /** Perform the operation as root */
+  asRoot?: boolean;
+}
+
+export interface RenameOptions {
+  asRoot?: boolean;
+}
+
+export interface ChownOptions {
+  /** User ID or user name */
+  uid?: number | string;
+  /** Group ID or group name */
+  gid?: number | string;
+  recursive?: boolean;
+  asRoot?: boolean;
+}
+
+export interface FilesystemWatchOptions {
+  recursive?: boolean;
+}
+
+export interface FilesystemWatchEvent {
+  type: 'subscribed' | 'event' | 'error';
+  paths?: string[];
+  path?: string;
+  event?: 'write' | 'create' | 'remove' | 'rename' | 'chmod';
+  timestamp?: string;
+  size?: number;
+  isDir?: boolean;
+  message?: string;
 }
 
 /**
@@ -788,4 +980,3 @@ export interface FsErrorResponse {
   code?: string;
   path?: string;
 }
-

--- a/src/watch.ts
+++ b/src/watch.ts
@@ -1,0 +1,129 @@
+import { EventEmitter } from 'node:events';
+import type { SpritesClient } from './client.js';
+import type { FilesystemWatchEvent, PortWatchEvent } from './types.js';
+
+class WebSocketJSONStream<T> extends EventEmitter implements AsyncIterable<T> {
+  private ws: WebSocket | null = null;
+  private queue: T[] = [];
+  private waiters: Array<{
+    resolve: (event: T | null) => void;
+    reject: (error: Error) => void;
+  }> = [];
+  private closed = false;
+  private finished = false;
+  private terminalError: Error | null = null;
+
+  protected async connectURL(url: string, token: string, initialMessage?: unknown): Promise<void> {
+    if (this.ws) throw new Error('Watcher already connected');
+    await new Promise<void>((resolve, reject) => {
+      const ws = new WebSocket(url, { headers: { 'Authorization': `Bearer ${token}` } });
+      this.ws = ws;
+      let connected = false;
+      ws.addEventListener('open', () => {
+        connected = true;
+        if (initialMessage !== undefined) ws.send(JSON.stringify(initialMessage));
+        resolve();
+      });
+      ws.addEventListener('message', event => {
+        if (typeof event.data !== 'string') return;
+        try {
+          const value = JSON.parse(event.data) as T;
+          this.emit('event', value);
+          const waiter = this.waiters.shift();
+          if (waiter) waiter.resolve(value); else this.queue.push(value);
+        } catch {
+          // Ignore malformed event frames.
+        }
+      });
+      ws.addEventListener('error', (event: any) => {
+        const error = new Error(`WebSocket error: ${event?.message || 'unknown'} (url: ${url})`);
+        if (ws.readyState === WebSocket.CONNECTING) {
+          reject(error);
+        } else {
+          this.fail(error);
+        }
+      });
+      ws.addEventListener('close', () => {
+        if (!connected) reject(new Error(`WebSocket closed before open (url: ${url})`));
+        this.finish();
+      });
+    });
+  }
+
+  async next(): Promise<T | null> {
+    const event = this.queue.shift();
+    if (event !== undefined) return event;
+    if (this.terminalError) throw this.terminalError;
+    if (this.closed) return null;
+    return new Promise((resolve, reject) => this.waiters.push({ resolve, reject }));
+  }
+
+  close(): void {
+    if (this.closed) return;
+    this.closed = true;
+    this.ws?.close(1000, '');
+    this.finish();
+  }
+
+  isClosed(): boolean {
+    return this.closed;
+  }
+
+  async *[Symbol.asyncIterator](): AsyncIterableIterator<T> {
+    try {
+      let event: T | null;
+      while ((event = await this.next()) !== null) yield event;
+    } finally {
+      this.close();
+    }
+  }
+
+  private finish(): void {
+    if (this.finished) return;
+    this.finished = true;
+    if (!this.closed) this.closed = true;
+    for (const waiter of this.waiters.splice(0)) waiter.resolve(null);
+    this.emit('close');
+  }
+
+  private fail(error: Error): void {
+    if (this.finished) return;
+    this.terminalError = error;
+    for (const waiter of this.waiters.splice(0)) waiter.reject(error);
+    this.finish();
+    if (this.listenerCount('error') > 0) this.emit('error', error);
+  }
+}
+
+export class PortWatcher extends WebSocketJSONStream<PortWatchEvent> {
+  constructor(private client: SpritesClient, private spriteName: string) { super(); }
+
+  async connect(): Promise<void> {
+    let baseURL = this.client.baseURL;
+    if (baseURL.startsWith('http')) baseURL = `ws${baseURL.slice(4)}`;
+    await this.connectURL(
+      `${baseURL}/v1/sprites/${encodeURIComponent(this.spriteName)}/ports/watch`,
+      this.client.token
+    );
+  }
+}
+
+export class FilesystemWatcher extends WebSocketJSONStream<FilesystemWatchEvent> {
+  constructor(
+    private client: SpritesClient,
+    private spriteName: string,
+    private paths: string[],
+    private workingDir: string,
+    private recursive: boolean
+  ) { super(); }
+
+  async connect(): Promise<void> {
+    let baseURL = this.client.baseURL;
+    if (baseURL.startsWith('http')) baseURL = `ws${baseURL.slice(4)}`;
+    await this.connectURL(
+      `${baseURL}/v1/sprites/${encodeURIComponent(this.spriteName)}/fs/watch`,
+      this.client.token,
+      { type: 'subscribe', paths: this.paths, recursive: this.recursive, workingDir: this.workingDir }
+    );
+  }
+}


### PR DESCRIPTION
## Summary

- complete the JavaScript SDK surface for current Sprite management and environment APIs
- add live Sprite, port, filesystem, session-kill, and service-log streams
- expand filesystem, service, policy, execution, lifecycle, and proxy support
- harden URL encoding, API error handling, HTTP execution cancellation, and watcher error propagation
- add comprehensive runtime and type-level coverage for the public interface
- advance the development package version from 0.0.1-dev to 0.1.0-dev

## User impact

JavaScript and TypeScript consumers can use the current Sprites API without dropping down to raw HTTP calls. Public paths are safely encoded, server response fields map consistently to SDK types, stream failures reach async iterators, and rate-limit errors retain structured details.

The HTTP exec endpoint still uses type-prefixed frames without explicit lengths. The SDK now rejects detectable rechunking, cancels failed streams, supports abort signals and timeouts, and documents that WebSocket exec is preferred for large output until the server protocol is length-prefixed.

## Deployment

Library-only change. No service migration or coordinated backend deployment is required. After merge, tag v0.1.0 to have the publish workflow release npm version 0.1.0.

## Validation

- npm test: 68 passed
- npm pack --dry-run: @fly/sprites@0.1.0-dev, 44 packaged files
- git diff --check
- live integration suite skipped because SPRITES_TEST_TOKEN was not set