### PR TITLE
Keep quiet exec WebSockets open

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,10 @@ const { stdout, stderr } = await sprite.exec('ls -la');
 console.log(stdout);
 ```
 
+WebSocket commands may remain quiet for extended periods; the SDK waits for the
+server to report command completion instead of treating a lack of output as a
+connection failure.
+
 ### TTY Mode
 
 ```typescript

--- a/src/public-api.test.ts
+++ b/src/public-api.test.ts
@@ -86,6 +86,22 @@ describe('package exports', () => {
 });
 
 describe('SpriteCommand and Sprite execution interfaces', () => {
+  it('keeps a quiet command open until the server exits it', async (t) => {
+    t.mock.timers.enable({ apis: ['setInterval', 'Date'] });
+    installWebSocket();
+    const sprite = new SpritesClient('token', { baseURL: 'https://example.test' }).sprite('demo');
+    const command = new SpriteCommand(sprite, 'sleep', ['120'], { tty: false });
+    await command.start();
+
+    const ws = MockWebSocket.instances[0];
+    t.mock.timers.tick(60_000);
+
+    assert.equal(ws.readyState, MockWebSocket.OPEN);
+    const waited = command.wait();
+    ws.dispatch('message', { data: binary(StreamID.Exit, 0) });
+    assert.equal(await waited, 0);
+  });
+
   it('starts, streams, signals, resizes, reports exit, and waits', async () => {
     installWebSocket();
     const sprite = new SpritesClient('token', { baseURL: 'https://example.test' }).sprite('demo/name');

--- a/src/websocket.ts
+++ b/src/websocket.ts
@@ -10,10 +10,6 @@ import { EventEmitter } from 'node:events';
 import { Writable } from 'node:stream';
 import { StreamID, ControlMessage } from './types.js';
 
-// WebSocket keepalive timeouts (matching Go SDK)
-const WS_PING_INTERVAL = 15_000; // 15 seconds
-const WS_PONG_WAIT = 45_000; // 45 seconds
-
 /**
  * WebSocket command execution handler
  */
@@ -23,9 +19,6 @@ export class WSCommand extends EventEmitter {
   private tty: boolean;
   private started: boolean = false;
   private done: boolean = false;
-  private pingInterval: ReturnType<typeof setInterval> | null = null;
-  private pongTimeout: ReturnType<typeof setTimeout> | null = null;
-  private lastPongTime: number = 0;
 
   /** Whether this is attaching to an existing session */
   isAttach: boolean = false;
@@ -77,9 +70,6 @@ export class WSCommand extends EventEmitter {
               return;
             }
           }
-
-          // Start keepalive ping/pong
-          this.startKeepalive();
 
           resolved = true;
           resolve();
@@ -149,61 +139,9 @@ export class WSCommand extends EventEmitter {
   }
 
   /**
-   * Start keepalive ping/pong mechanism
-   */
-  private startKeepalive(): void {
-    this.lastPongTime = Date.now();
-
-    // Send pings at regular intervals
-    this.pingInterval = setInterval(() => {
-      if (!this.ws || this.ws.readyState !== WebSocket.OPEN) {
-        this.stopKeepalive();
-        return;
-      }
-
-      // Check if we've received a pong recently
-      const timeSinceLastPong = Date.now() - this.lastPongTime;
-      if (timeSinceLastPong > WS_PONG_WAIT) {
-        // Connection appears dead
-        this.emit('error', new Error('WebSocket keepalive timeout'));
-        this.close();
-        return;
-      }
-
-      // Note: Browser WebSocket API doesn't expose ping/pong directly.
-      // Node.js WebSocket implementation may support it differently.
-      // The server-side handles keepalive; we just track activity.
-    }, WS_PING_INTERVAL);
-  }
-
-  /**
-   * Stop keepalive mechanism
-   */
-  private stopKeepalive(): void {
-    if (this.pingInterval) {
-      clearInterval(this.pingInterval);
-      this.pingInterval = null;
-    }
-    if (this.pongTimeout) {
-      clearTimeout(this.pongTimeout);
-      this.pongTimeout = null;
-    }
-  }
-
-  /**
-   * Reset keepalive timer (call on any message received)
-   */
-  private resetKeepalive(): void {
-    this.lastPongTime = Date.now();
-  }
-
-  /**
    * Handle incoming WebSocket messages
    */
   private handleMessage(event: MessageEvent): void {
-    // Reset keepalive on any message received
-    this.resetKeepalive();
-
     if (this.tty) {
       // TTY mode
       if (typeof event.data === 'string') {
@@ -255,8 +193,6 @@ export class WSCommand extends EventEmitter {
    * Handle WebSocket close
    */
   private handleClose(event: CloseEvent): void {
-    this.stopKeepalive();
-
     if (!this.done) {
       this.done = true;
 
@@ -348,7 +284,6 @@ export class WSCommand extends EventEmitter {
    * Close the WebSocket connection
    */
   close(): void {
-    this.stopKeepalive();
     if (this.ws && this.ws.readyState === WebSocket.OPEN) {
       this.ws.close(1000, '');
     }
@@ -369,4 +304,3 @@ export class WSCommand extends EventEmitter {
     });
   }
 }
-


### PR DESCRIPTION
## Summary

- remove the application-message inactivity timer from exec WebSockets
- keep quiet commands connected until the server reports completion or closes the connection
- document the behavior for long-running commands without output

## User impact

Commands that legitimately produce no output for more than 45 seconds no longer fail with a client-side keepalive timeout.

The WebSocket API used by this SDK does not expose protocol ping/pong events, so application-message silence is not evidence that the connection is unhealthy.

## Validation

- `npm test` (69 passed, 1 integration suite skipped because `SPRITES_TEST_TOKEN` is not set)
- regression coverage advances the clock by 60 seconds with no command output and confirms the connection remains open until an exit frame arrives

## Versioning and deployment

This is a backwards-compatible patch fix. The repository's publish workflow owns the package version, so this PR does not independently change `package.json`; no service deployment is required.

Fixes #13.
