### PR TITLE
Close exec WebSockets on every terminal path

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,8 @@ interface SpawnOptions {
 Extends SpawnOptions with:
 - `encoding?: BufferEncoding` - Output encoding (default: 'utf8')
 - `maxBuffer?: number` - Maximum buffer size (default: 10MB)
+- `signal?: AbortSignal` - Abort execution and close its WebSocket
+- `timeoutMs?: number` - Abort execution after this many milliseconds
 
 ## Examples
 

--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ Represents a running command. Extends EventEmitter.
 **Methods:**
 - `wait(): Promise<number>` - Wait for exit and return exit code
 - `kill(signal?: string): void` - Kill the command
+- `close(): void` - Close the command's WebSocket and end its output streams
 - `resize(cols: number, rows: number): void` - Resize TTY (if TTY mode enabled)
 - `exitCode(): number` - Get exit code (-1 if not exited)
 
@@ -163,7 +164,7 @@ Extends SpawnOptions with:
 - `encoding?: BufferEncoding` - Output encoding (default: 'utf8')
 - `maxBuffer?: number` - Maximum buffer size (default: 10MB)
 - `signal?: AbortSignal` - Abort execution and close its WebSocket
-- `timeoutMs?: number` - Abort execution after this many milliseconds
+- `timeout?: number` - Abort execution after this many milliseconds (`0` disables the timeout)
 
 ## Examples
 

--- a/src/client.test.ts
+++ b/src/client.test.ts
@@ -61,11 +61,14 @@ describe('SpritesClient public interface', () => {
     const settings: URLSettings = { auth: 'future-api-auth-mode' };
     // @ts-expect-error HTTP exec cannot create detachable sessions.
     const unsupported: HTTPExecOptions = { detachable: true };
+    // @ts-expect-error HTTP and WebSocket exec both use the Node-compatible timeout option.
+    const unsupportedTimeoutName: HTTPExecOptions = { timeoutMs: 100 };
 
     assert.equal(list.sprites[0].labels, undefined);
     assert.equal(list.running, undefined);
     assert.equal(settings.auth, 'future-api-auth-mode');
     void unsupported;
+    void unsupportedTimeoutName;
   });
 
   it('constructs handles and preserves client options', () => {

--- a/src/control.ts
+++ b/src/control.ts
@@ -162,6 +162,7 @@ export class OpConn extends EventEmitter {
   close(): void {
     if (this.closed) return;
     this.closed = true;
+    this.cc.clearOpConn(this);
     this.emit('close');
   }
 
@@ -229,7 +230,9 @@ export class ControlConnection extends EventEmitter {
   /**
    * Clear the operation connection (called by pool on release)
    */
-  clearOpConn(): void {
+  clearOpConn(opConn?: OpConn): void {
+    if (opConn && this.opConn !== opConn) return;
+    this.opActive = false;
     this.opConn = null;
   }
 
@@ -275,6 +278,7 @@ export class ControlConnection extends EventEmitter {
             this.emit('error', error);
           } else {
             // Pre-connection error: reject the connect() promise
+            this.close();
             reject(error);
           }
         });
@@ -333,10 +337,13 @@ export class ControlConnection extends EventEmitter {
         break;
 
       case TYPE_OP_ERROR:
-        if (this.opConn) {
-          const error = (msg.args?.error as string) ?? 'unknown error';
-          this.opConn.emit('error', new Error(error));
-          this.opConn.complete();
+        {
+          const opConn = this.opConn;
+          if (opConn) {
+            const error = (msg.args?.error as string) ?? 'unknown error';
+            opConn.emit('error', new Error(error));
+            opConn.complete();
+          }
         }
         this.opActive = false;
         this.opConn = null;
@@ -421,13 +428,16 @@ export class ControlConnection extends EventEmitter {
    * Close the control connection
    */
   close(): void {
+    this.closed = true;
     if (this.opConn) {
       this.opConn.close();
     }
-    if (this.ws && this.ws.readyState === WebSocket.OPEN) {
+    if (this.ws && (
+      this.ws.readyState === WebSocket.CONNECTING ||
+      this.ws.readyState === WebSocket.OPEN
+    )) {
       this.ws.close(1000, '');
     }
-    this.closed = true;
   }
 
   /**
@@ -468,6 +478,8 @@ export class ControlPool {
       throw new Error('Pool is closed');
     }
 
+    this.conns = this.conns.filter((cc) => !cc.isClosed());
+
     // Try to find an available connection
     for (const cc of this.conns) {
       if (!cc.isClosed() && !cc.isActive()) {
@@ -497,6 +509,15 @@ export class ControlPool {
   release(cc: ControlConnection): void {
     cc.setActive(false);
     cc.clearOpConn();
+
+    if (cc.isClosed()) {
+      this.conns = this.conns.filter((connection) => connection !== cc);
+      const waiter = this.waiters.shift();
+      if (waiter) {
+        this.acquire().then(waiter.resolve, waiter.reject);
+      }
+      return;
+    }
 
     // If there are waiters, give them this connection
     if (this.waiters.length > 0) {

--- a/src/exec.ts
+++ b/src/exec.ts
@@ -24,6 +24,13 @@ export class SessionKillStream extends NDJSONStream<SessionKillEvent> {
   }
 }
 
+class ControlConnectionUnavailableError extends Error {
+  constructor(cause: unknown) {
+    super('Control connection unavailable', { cause });
+    this.name = 'ControlConnectionUnavailableError';
+  }
+}
+
 /**
  * Represents a command running on a sprite
  * Mirrors the Node.js ChildProcess API
@@ -308,8 +315,15 @@ export async function execFile(
   if (!options.sessionId && sprite.useControlMode()) {
     try {
       return await execFileViaControl(sprite, file, args, options);
-    } catch {
-      // Control connection failed (server may not support it), fall back to regular WebSocket
+    } catch (error) {
+      if (!(error instanceof ControlConnectionUnavailableError)) {
+        throw error;
+      }
+      if (options.signal?.aborted) {
+        throw abortError();
+      }
+      // The server may not support control mode. Fall back only when the
+      // control connection itself could not be established.
     }
   }
 
@@ -323,59 +337,35 @@ export async function execFile(
     const stderrChunks: Buffer[] = [];
     let stdoutLength = 0;
     let stderrLength = 0;
-    let settled = false;
-    let timeout: ReturnType<typeof setTimeout> | undefined;
+    let removeCancellation = () => {};
 
-    const cleanup = () => {
-      if (timeout !== undefined) {
-        clearTimeout(timeout);
-      }
-      options.signal?.removeEventListener('abort', onAbort);
+    const settler = createExecSettler(resolve, reject, () => {
+      removeCancellation();
       cmd.close();
-    };
-
-    const settle = (complete: () => void) => {
-      if (settled) return;
-      settled = true;
-      cleanup();
-      complete();
-    };
-
-    const rejectWith = (error: Error) => {
-      settle(() => reject(error));
-    };
-
-    const resolveWith = (result: ExecResult) => {
-      settle(() => resolve(result));
-    };
-
-    const onAbort = () => {
-      cmd.kill();
-      rejectWith(abortError());
-    };
+    });
 
     cmd.stdout.on('data', (chunk: Buffer) => {
-      if (settled) return;
+      if (settler.isSettled()) return;
       stdoutChunks.push(chunk);
       stdoutLength += chunk.length;
       if (stdoutLength > maxBuffer) {
         cmd.kill();
-        rejectWith(new Error(`stdout maxBuffer exceeded`));
+        settler.reject(new Error(`stdout maxBuffer exceeded`));
       }
     });
 
     cmd.stderr.on('data', (chunk: Buffer) => {
-      if (settled) return;
+      if (settler.isSettled()) return;
       stderrChunks.push(chunk);
       stderrLength += chunk.length;
       if (stderrLength > maxBuffer) {
         cmd.kill();
-        rejectWith(new Error(`stderr maxBuffer exceeded`));
+        settler.reject(new Error(`stderr maxBuffer exceeded`));
       }
     });
 
     cmd.on('exit', (code: number) => {
-      if (settled) return;
+      if (settler.isSettled()) return;
       const stdoutBuffer = Buffer.concat(stdoutChunks);
       const stderrBuffer = Buffer.concat(stderrChunks);
 
@@ -387,25 +377,26 @@ export async function execFile(
 
       if (code !== 0) {
         const error = new ExecError(`Command failed with exit code ${code}`, result);
-        rejectWith(error);
+        settler.reject(error);
       } else {
-        resolveWith(result);
+        settler.resolve(result);
       }
     });
 
     cmd.on('error', (error: Error) => {
-      rejectWith(error);
+      settler.reject(error);
     });
 
-    options.signal?.addEventListener('abort', onAbort, { once: true });
-    if (options.timeoutMs !== undefined) {
-      timeout = setTimeout(() => {
-        cmd.kill();
-        rejectWith(new Error(`Command timed out after ${options.timeoutMs} ms`));
-      }, options.timeoutMs);
+    const cancellation = createExecCancellation(options, () => {
+      // signal() is a no-op while connecting; close() in the settler cleanup
+      // still disconnects the socket so the server can reap the process.
+      cmd.kill();
+    }, settler.reject);
+    removeCancellation = cancellation.cleanup;
+    cancellation.start();
+    if (!settler.isSettled()) {
+      cmd.start().catch(settler.reject);
     }
-
-    cmd.start().catch(rejectWith);
   });
 }
 
@@ -551,7 +542,12 @@ async function execFileViaControl(
   const maxBuffer = options.maxBuffer || 10 * 1024 * 1024; // 10MB default
 
   // Get a control connection from the pool
-  const cc = await sprite.getControlConnection();
+  let cc;
+  try {
+    cc = await sprite.getControlConnection();
+  } catch (error) {
+    throw new ControlConnectionUnavailableError(error);
+  }
 
   // Build operation options
   const opOptions = {
@@ -573,75 +569,71 @@ async function execFileViaControl(
       const stderrChunks: Buffer[] = [];
       let stdoutLength = 0;
       let stderrLength = 0;
-      let settled = false;
-      let timeout: ReturnType<typeof setTimeout> | undefined;
+      let removeCancellation = () => {};
 
-      const cleanup = () => {
-        if (timeout !== undefined) {
-          clearTimeout(timeout);
-        }
-        options.signal?.removeEventListener('abort', onAbort);
+      const settler = createExecSettler(resolve, reject, () => {
+        removeCancellation();
         op.close();
-      };
+      });
 
-      const settle = (complete: () => void) => {
-        if (settled) return;
-        settled = true;
-        cleanup();
-        complete();
-      };
-
-      const rejectWith = (error: Error) => {
-        settle(() => reject(error));
-      };
-
-      const resolveWith = (result: ExecResult) => {
-        settle(() => resolve(result));
-      };
-
-      const onAbort = () => {
-        op.signal('TERM');
-        rejectWith(abortError());
+      const cancelControlOp = (signal: string) => {
+        try {
+          op.signal(signal);
+        } catch {
+          // Closing the control connection below is the cancellation fallback.
+        } finally {
+          // Do not return a connection to the pool while the server may still
+          // be completing its canceled operation. A later exec will establish
+          // a fresh control connection.
+          cc.close();
+        }
       };
 
       op.on('stdout', (data: Buffer) => {
-        if (settled) return;
+        if (settler.isSettled()) return;
         stdoutChunks.push(data);
         stdoutLength += data.length;
         if (stdoutLength > maxBuffer) {
-          op.signal('KILL');
-          rejectWith(new Error(`stdout maxBuffer exceeded`));
+          cancelControlOp('KILL');
+          settler.reject(new Error(`stdout maxBuffer exceeded`));
         }
       });
 
       op.on('stderr', (data: Buffer) => {
-        if (settled) return;
+        if (settler.isSettled()) return;
         stderrChunks.push(data);
         stderrLength += data.length;
         if (stderrLength > maxBuffer) {
-          op.signal('KILL');
-          rejectWith(new Error(`stderr maxBuffer exceeded`));
+          cancelControlOp('KILL');
+          settler.reject(new Error(`stderr maxBuffer exceeded`));
         }
       });
 
       op.on('error', (error: Error) => {
-        rejectWith(error);
+        settler.reject(error);
       });
 
       // Send stdin EOF since we're not providing input
-      op.sendEOF();
+      try {
+        op.sendEOF();
+      } catch (error) {
+        cc.close();
+        settler.reject(error as Error);
+      }
 
-      options.signal?.addEventListener('abort', onAbort, { once: true });
-      if (options.timeoutMs !== undefined) {
-        timeout = setTimeout(() => {
-          op.signal('TERM');
-          rejectWith(new Error(`Command timed out after ${options.timeoutMs} ms`));
-        }, options.timeoutMs);
+      if (!settler.isSettled()) {
+        const cancellation = createExecCancellation(
+          options,
+          () => cancelControlOp('TERM'),
+          settler.reject
+        );
+        removeCancellation = cancellation.cleanup;
+        cancellation.start();
       }
 
       // Wait for completion
       op.wait().then((code) => {
-        if (settled) return;
+        if (settler.isSettled()) return;
         const stdoutBuffer = Buffer.concat(stdoutChunks);
         const stderrBuffer = Buffer.concat(stderrChunks);
 
@@ -653,11 +645,11 @@ async function execFileViaControl(
 
         if (code !== 0) {
           const error = new ExecError(`Command failed with exit code ${code}`, result);
-          rejectWith(error);
+          settler.reject(error);
         } else {
-          resolveWith(result);
+          settler.resolve(result);
         }
-      }).catch(rejectWith);
+      }).catch(settler.reject);
     });
   } finally {
     // Always release the connection back to the pool
@@ -667,11 +659,79 @@ async function execFileViaControl(
 
 function validateExecCancellationOptions(options: ExecOptions): void {
   if (
-    options.timeoutMs !== undefined &&
-    (!Number.isFinite(options.timeoutMs) || options.timeoutMs < 0)
+    options.timeout !== undefined &&
+    (!Number.isFinite(options.timeout) || options.timeout < 0)
   ) {
-    throw new TypeError('timeoutMs must be a non-negative finite number');
+    throw new TypeError('timeout must be a non-negative finite number');
   }
+}
+
+function createExecSettler<T>(
+  resolve: (value: T) => void,
+  reject: (error: Error) => void,
+  cleanup: () => void
+): {
+  isSettled: () => boolean;
+  resolve: (value: T) => void;
+  reject: (error: Error) => void;
+} {
+  let settled = false;
+
+  const settle = (complete: () => void) => {
+    if (settled) return;
+    settled = true;
+    try {
+      cleanup();
+    } finally {
+      complete();
+    }
+  };
+
+  return {
+    isSettled: () => settled,
+    resolve: (value) => settle(() => resolve(value)),
+    reject: (error) => settle(() => reject(error)),
+  };
+}
+
+function createExecCancellation(
+  options: ExecOptions,
+  cancel: () => void,
+  reject: (error: Error) => void
+): { start: () => void; cleanup: () => void } {
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+
+  const cancelAndReject = (error: Error) => {
+    try {
+      cancel();
+    } catch {
+      // Preserve the requested abort/timeout error. Cleanup still runs when
+      // reject() settles the operation.
+    } finally {
+      reject(error);
+    }
+  };
+  const onAbort = () => cancelAndReject(abortError());
+
+  return {
+    start: () => {
+      options.signal?.addEventListener('abort', onAbort, { once: true });
+      if (options.timeout !== undefined && options.timeout > 0) {
+        timeout = setTimeout(
+          () => cancelAndReject(new Error(`Command timed out after ${options.timeout} ms`)),
+          options.timeout
+        );
+      }
+
+      if (options.signal?.aborted) {
+        onAbort();
+      }
+    },
+    cleanup: () => {
+      if (timeout !== undefined) clearTimeout(timeout);
+      options.signal?.removeEventListener('abort', onAbort);
+    },
+  };
 }
 
 function abortError(): Error {

--- a/src/exec.ts
+++ b/src/exec.ts
@@ -227,6 +227,13 @@ export class SpriteCommand extends EventEmitter {
   }
 
   /**
+   * Close the command's WebSocket connection.
+   */
+  close(): void {
+    this.wsCmd.close();
+  }
+
+  /**
    * Send a signal to the remote process
    */
   signal(sig: string): void {
@@ -292,6 +299,11 @@ export async function execFile(
   args: string[] = [],
   options: ExecOptions = {}
 ): Promise<ExecResult> {
+  validateExecCancellationOptions(options);
+  if (options.signal?.aborted) {
+    throw abortError();
+  }
+
   // Use control mode if enabled and not attaching to a session
   if (!options.sessionId && sprite.useControlMode()) {
     try {
@@ -311,26 +323,59 @@ export async function execFile(
     const stderrChunks: Buffer[] = [];
     let stdoutLength = 0;
     let stderrLength = 0;
+    let settled = false;
+    let timeout: ReturnType<typeof setTimeout> | undefined;
+
+    const cleanup = () => {
+      if (timeout !== undefined) {
+        clearTimeout(timeout);
+      }
+      options.signal?.removeEventListener('abort', onAbort);
+      cmd.close();
+    };
+
+    const settle = (complete: () => void) => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      complete();
+    };
+
+    const rejectWith = (error: Error) => {
+      settle(() => reject(error));
+    };
+
+    const resolveWith = (result: ExecResult) => {
+      settle(() => resolve(result));
+    };
+
+    const onAbort = () => {
+      cmd.kill();
+      rejectWith(abortError());
+    };
 
     cmd.stdout.on('data', (chunk: Buffer) => {
+      if (settled) return;
       stdoutChunks.push(chunk);
       stdoutLength += chunk.length;
       if (stdoutLength > maxBuffer) {
         cmd.kill();
-        reject(new Error(`stdout maxBuffer exceeded`));
+        rejectWith(new Error(`stdout maxBuffer exceeded`));
       }
     });
 
     cmd.stderr.on('data', (chunk: Buffer) => {
+      if (settled) return;
       stderrChunks.push(chunk);
       stderrLength += chunk.length;
       if (stderrLength > maxBuffer) {
         cmd.kill();
-        reject(new Error(`stderr maxBuffer exceeded`));
+        rejectWith(new Error(`stderr maxBuffer exceeded`));
       }
     });
 
     cmd.on('exit', (code: number) => {
+      if (settled) return;
       const stdoutBuffer = Buffer.concat(stdoutChunks);
       const stderrBuffer = Buffer.concat(stderrChunks);
 
@@ -342,17 +387,25 @@ export async function execFile(
 
       if (code !== 0) {
         const error = new ExecError(`Command failed with exit code ${code}`, result);
-        reject(error);
+        rejectWith(error);
       } else {
-        resolve(result);
+        resolveWith(result);
       }
     });
 
     cmd.on('error', (error: Error) => {
-      reject(error);
+      rejectWith(error);
     });
 
-    cmd.start().catch(reject);
+    options.signal?.addEventListener('abort', onAbort, { once: true });
+    if (options.timeoutMs !== undefined) {
+      timeout = setTimeout(() => {
+        cmd.kill();
+        rejectWith(new Error(`Command timed out after ${options.timeoutMs} ms`));
+      }, options.timeoutMs);
+    }
+
+    cmd.start().catch(rejectWith);
   });
 }
 
@@ -520,34 +573,75 @@ async function execFileViaControl(
       const stderrChunks: Buffer[] = [];
       let stdoutLength = 0;
       let stderrLength = 0;
+      let settled = false;
+      let timeout: ReturnType<typeof setTimeout> | undefined;
+
+      const cleanup = () => {
+        if (timeout !== undefined) {
+          clearTimeout(timeout);
+        }
+        options.signal?.removeEventListener('abort', onAbort);
+        op.close();
+      };
+
+      const settle = (complete: () => void) => {
+        if (settled) return;
+        settled = true;
+        cleanup();
+        complete();
+      };
+
+      const rejectWith = (error: Error) => {
+        settle(() => reject(error));
+      };
+
+      const resolveWith = (result: ExecResult) => {
+        settle(() => resolve(result));
+      };
+
+      const onAbort = () => {
+        op.signal('TERM');
+        rejectWith(abortError());
+      };
 
       op.on('stdout', (data: Buffer) => {
+        if (settled) return;
         stdoutChunks.push(data);
         stdoutLength += data.length;
         if (stdoutLength > maxBuffer) {
           op.signal('KILL');
-          reject(new Error(`stdout maxBuffer exceeded`));
+          rejectWith(new Error(`stdout maxBuffer exceeded`));
         }
       });
 
       op.on('stderr', (data: Buffer) => {
+        if (settled) return;
         stderrChunks.push(data);
         stderrLength += data.length;
         if (stderrLength > maxBuffer) {
           op.signal('KILL');
-          reject(new Error(`stderr maxBuffer exceeded`));
+          rejectWith(new Error(`stderr maxBuffer exceeded`));
         }
       });
 
       op.on('error', (error: Error) => {
-        reject(error);
+        rejectWith(error);
       });
 
       // Send stdin EOF since we're not providing input
       op.sendEOF();
 
+      options.signal?.addEventListener('abort', onAbort, { once: true });
+      if (options.timeoutMs !== undefined) {
+        timeout = setTimeout(() => {
+          op.signal('TERM');
+          rejectWith(new Error(`Command timed out after ${options.timeoutMs} ms`));
+        }, options.timeoutMs);
+      }
+
       // Wait for completion
       op.wait().then((code) => {
+        if (settled) return;
         const stdoutBuffer = Buffer.concat(stdoutChunks);
         const stderrBuffer = Buffer.concat(stderrChunks);
 
@@ -559,14 +653,29 @@ async function execFileViaControl(
 
         if (code !== 0) {
           const error = new ExecError(`Command failed with exit code ${code}`, result);
-          reject(error);
+          rejectWith(error);
         } else {
-          resolve(result);
+          resolveWith(result);
         }
-      }).catch(reject);
+      }).catch(rejectWith);
     });
   } finally {
     // Always release the connection back to the pool
     releaseControlConnection(sprite, cc);
   }
+}
+
+function validateExecCancellationOptions(options: ExecOptions): void {
+  if (
+    options.timeoutMs !== undefined &&
+    (!Number.isFinite(options.timeoutMs) || options.timeoutMs < 0)
+  ) {
+    throw new TypeError('timeoutMs must be a non-negative finite number');
+  }
+}
+
+function abortError(): Error {
+  const error = new Error('Command execution was aborted');
+  error.name = 'AbortError';
+  return error;
 }

--- a/src/public-api.test.ts
+++ b/src/public-api.test.ts
@@ -148,6 +148,46 @@ describe('SpriteCommand and Sprite execution interfaces', () => {
     await assert.rejects(filePromise, (error: any) => error.exitCode === 2 && Buffer.isBuffer(error.stderr));
   });
 
+  it('closes the exec WebSocket when execution fails', async () => {
+    installWebSocket();
+    const sprite = new SpritesClient('token', { baseURL: 'https://example.test' }).sprite('demo');
+    const execution = sprite.execFile('command');
+    await new Promise(resolve => setImmediate(resolve));
+
+    const ws = MockWebSocket.instances[0];
+    ws.dispatch('error', { message: 'connection failed' });
+
+    await assert.rejects(execution, /connection failed/);
+    assert.equal(ws.readyState, MockWebSocket.CLOSED);
+  });
+
+  it('closes the exec WebSocket when execution times out', async (t) => {
+    t.mock.timers.enable({ apis: ['setTimeout'] });
+    installWebSocket();
+    const sprite = new SpritesClient('token', { baseURL: 'https://example.test' }).sprite('demo');
+    const execution = sprite.execFile('sleep', ['120'], { timeoutMs: 50 });
+    await new Promise(resolve => setImmediate(resolve));
+
+    const ws = MockWebSocket.instances[0];
+    t.mock.timers.tick(50);
+
+    await assert.rejects(execution, /timed out after 50 ms/);
+    assert.equal(ws.readyState, MockWebSocket.CLOSED);
+  });
+
+  it('closes a connecting exec WebSocket when execution is aborted', async () => {
+    installWebSocket();
+    const sprite = new SpritesClient('token', { baseURL: 'https://example.test' }).sprite('demo');
+    const abort = new AbortController();
+    const execution = sprite.execFile('sleep', ['120'], { signal: abort.signal });
+
+    abort.abort();
+
+    await assert.rejects(execution, (error: any) => error.name === 'AbortError');
+    await new Promise(resolve => setImmediate(resolve));
+    assert.equal(MockWebSocket.instances[0].readyState, MockWebSocket.CLOSED);
+  });
+
   it('executes over HTTP and streams session-kill progress', async () => {
     const encoder = new TextEncoder();
     const responses = [

--- a/src/public-api.test.ts
+++ b/src/public-api.test.ts
@@ -161,6 +161,19 @@ describe('SpriteCommand and Sprite execution interfaces', () => {
     assert.equal(ws.readyState, MockWebSocket.CLOSED);
   });
 
+  it('closes the exec WebSocket when maxBuffer is exceeded', async () => {
+    installWebSocket();
+    const sprite = new SpritesClient('token', { baseURL: 'https://example.test' }).sprite('demo');
+    const execution = sprite.execFile('printf', [], { maxBuffer: 3 });
+    await new Promise(resolve => setImmediate(resolve));
+
+    const ws = MockWebSocket.instances[0];
+    ws.dispatch('message', { data: binary(StreamID.Stdout, ...Buffer.from('large')) });
+
+    await assert.rejects(execution, /stdout maxBuffer exceeded/);
+    assert.equal(ws.readyState, MockWebSocket.CLOSED);
+  });
+
   it('closes the exec WebSocket when execution times out', async (t) => {
     t.mock.timers.enable({ apis: ['setTimeout'] });
     installWebSocket();

--- a/src/public-api.test.ts
+++ b/src/public-api.test.ts
@@ -17,6 +17,7 @@ class MockWebSocket {
   static readonly CLOSING = 2;
   static readonly CLOSED = 3;
   static instances: MockWebSocket[] = [];
+  static failNextConnection: string | undefined;
 
   readonly url: string;
   readyState = MockWebSocket.CONNECTING;
@@ -27,7 +28,13 @@ class MockWebSocket {
   constructor(url: string | URL) {
     this.url = url.toString();
     MockWebSocket.instances.push(this);
+    const connectionError = MockWebSocket.failNextConnection;
+    MockWebSocket.failNextConnection = undefined;
     queueMicrotask(() => {
+      if (connectionError) {
+        this.dispatch('error', { message: connectionError });
+        return;
+      }
       this.readyState = MockWebSocket.OPEN;
       this.dispatch('open', {});
     });
@@ -60,6 +67,7 @@ class MockWebSocket {
 
 function installWebSocket(): void {
   MockWebSocket.instances = [];
+  MockWebSocket.failNextConnection = undefined;
   globalThis.WebSocket = MockWebSocket as unknown as typeof WebSocket;
 }
 
@@ -178,7 +186,7 @@ describe('SpriteCommand and Sprite execution interfaces', () => {
     t.mock.timers.enable({ apis: ['setTimeout'] });
     installWebSocket();
     const sprite = new SpritesClient('token', { baseURL: 'https://example.test' }).sprite('demo');
-    const execution = sprite.execFile('sleep', ['120'], { timeoutMs: 50 });
+    const execution = sprite.execFile('sleep', ['120'], { timeout: 50 });
     await new Promise(resolve => setImmediate(resolve));
 
     const ws = MockWebSocket.instances[0];
@@ -199,6 +207,133 @@ describe('SpriteCommand and Sprite execution interfaces', () => {
     await assert.rejects(execution, (error: any) => error.name === 'AbortError');
     await new Promise(resolve => setImmediate(resolve));
     assert.equal(MockWebSocket.instances[0].readyState, MockWebSocket.CLOSED);
+  });
+
+  it('ends streams and wait() when SpriteCommand.close() is called', async () => {
+    installWebSocket();
+    const sprite = new SpritesClient('token', { baseURL: 'https://example.test' }).sprite('demo');
+    const command = new SpriteCommand(sprite, 'sleep', ['120']);
+    command.stdout.resume();
+    command.stderr.resume();
+    const stdoutEnded = new Promise(resolve => command.stdout.once('end', resolve));
+    const stderrEnded = new Promise(resolve => command.stderr.once('end', resolve));
+    await command.start();
+
+    command.close();
+
+    assert.equal(await command.wait(), -1);
+    await Promise.all([stdoutEnded, stderrEnded]);
+    assert.equal(MockWebSocket.instances[0].readyState, MockWebSocket.CLOSED);
+  });
+
+  it('validates exec timeout, treats zero as disabled, and removes abort listeners', async () => {
+    installWebSocket();
+    const sprite = new SpritesClient('token', { baseURL: 'https://example.test' }).sprite('demo');
+    await assert.rejects(() => sprite.execFile('true', [], { timeout: -1 }), TypeError);
+    await assert.rejects(() => sprite.execFile('true', [], { timeout: Number.NaN }), TypeError);
+    assert.equal(MockWebSocket.instances.length, 0);
+
+    let removeCount = 0;
+    const listeners = new Set<unknown>();
+    const signal = {
+      aborted: false,
+      addEventListener: (_type: string, listener: unknown) => {
+        listeners.add(listener);
+      },
+      removeEventListener: (_type: string, listener: unknown) => {
+        removeCount++;
+        listeners.delete(listener);
+      },
+    } as unknown as AbortSignal;
+    const execution = sprite.execFile('true', [], { signal, timeout: 0 });
+    await new Promise(resolve => setImmediate(resolve));
+    const ws = MockWebSocket.instances[0];
+    ws.dispatch('message', { data: binary(StreamID.Exit, 0) });
+
+    assert.equal((await execution).exitCode, 0);
+    assert.equal(removeCount, 1);
+    assert.equal(listeners.size, 0);
+    assert.equal(ws.readyState, MockWebSocket.CLOSED);
+  });
+
+  it('does not retry an aborted control operation and uses control mode again', async () => {
+    installWebSocket();
+    const sprite = new SpritesClient('token', {
+      baseURL: 'https://example.test', controlMode: true,
+    }).sprite('demo');
+    const abort = new AbortController();
+    const execution = sprite.execFile('sleep', ['120'], { signal: abort.signal });
+    await new Promise(resolve => setImmediate(resolve));
+
+    abort.abort();
+
+    await assert.rejects(execution, (error: any) => error.name === 'AbortError');
+    assert.equal(MockWebSocket.instances.length, 1);
+    assert.match(MockWebSocket.instances[0].url, /\/control$/);
+    assert.equal(MockWebSocket.instances[0].readyState, MockWebSocket.CLOSED);
+
+    const nextExecution = sprite.execFile('echo', ['hi']);
+    await new Promise(resolve => setImmediate(resolve));
+    assert.equal(MockWebSocket.instances.length, 2);
+    const nextControl = MockWebSocket.instances[1];
+    assert.match(nextControl.url, /\/control$/);
+    nextControl.dispatch('message', {
+      data: binary(StreamID.Stdout, ...Buffer.from('hi\n')),
+    });
+    nextControl.dispatch('message', {
+      data: 'control:{"type":"op.complete","args":{"exitCode":0}}',
+    });
+    assert.deepEqual(await nextExecution, { stdout: 'hi\n', stderr: '', exitCode: 0 });
+  });
+
+  it('does not retry a timed-out control operation', async (t) => {
+    t.mock.timers.enable({ apis: ['setTimeout'] });
+    installWebSocket();
+    const sprite = new SpritesClient('token', {
+      baseURL: 'https://example.test', controlMode: true,
+    }).sprite('demo');
+    const execution = sprite.execFile('sleep', ['120'], { timeout: 50 });
+    await new Promise(resolve => setImmediate(resolve));
+
+    t.mock.timers.tick(50);
+
+    await assert.rejects(execution, /timed out after 50 ms/);
+    assert.equal(MockWebSocket.instances.length, 1);
+    assert.match(MockWebSocket.instances[0].url, /\/control$/);
+    assert.equal(MockWebSocket.instances[0].readyState, MockWebSocket.CLOSED);
+  });
+
+  it('falls back only when the control connection cannot be established', async () => {
+    installWebSocket();
+    const sprite = new SpritesClient('token', {
+      baseURL: 'https://example.test', controlMode: true,
+    }).sprite('demo');
+    MockWebSocket.failNextConnection = 'control unsupported';
+
+    const execution = sprite.execFile('echo', ['fallback']);
+    await new Promise(resolve => setImmediate(resolve));
+
+    assert.equal(MockWebSocket.instances.length, 2);
+    assert.match(MockWebSocket.instances[0].url, /\/control$/);
+    assert.match(MockWebSocket.instances[1].url, /\/exec\?/);
+    MockWebSocket.instances[1].dispatch('message', { data: binary(StreamID.Exit, 0) });
+    assert.equal((await execution).exitCode, 0);
+  });
+
+  it('does not fall back after a control operation has started', async () => {
+    installWebSocket();
+    const sprite = new SpritesClient('token', {
+      baseURL: 'https://example.test', controlMode: true,
+    }).sprite('demo');
+    const execution = sprite.execFile('false');
+    await new Promise(resolve => setImmediate(resolve));
+
+    MockWebSocket.instances[0].dispatch('message', {
+      data: 'control:{"type":"op.error","args":{"error":"failed"}}',
+    });
+
+    await assert.rejects(execution, /failed/);
+    assert.equal(MockWebSocket.instances.length, 1);
   });
 
   it('executes over HTTP and streams session-kill progress', async () => {
@@ -375,5 +510,23 @@ describe('control interfaces', () => {
     assert.ok(pooled instanceof ControlConnection);
     sprite.closeControlConnection();
     assert.equal(sprite.hasControlConnection(), false);
+  });
+
+  it('clears operation state when an OpConn is closed early', async () => {
+    installWebSocket();
+    const sprite = new SpritesClient('token', { baseURL: 'https://example.test' }).sprite('demo');
+    const connection = new ControlConnection(sprite);
+    await connection.connect();
+
+    const first = await connection.startOp('exec', { cmd: ['sleep', '120'] });
+    first.close();
+    const second = await connection.startOp('exec', { cmd: ['echo', 'hi'] });
+
+    const waited = second.wait();
+    MockWebSocket.instances[0].dispatch('message', {
+      data: 'control:{"type":"op.complete","args":{"exitCode":0}}',
+    });
+    assert.equal(await waited, 0);
+    connection.close();
   });
 });

--- a/src/types.ts
+++ b/src/types.ts
@@ -70,6 +70,10 @@ export interface ExecOptions extends SpawnOptions {
   encoding?: BufferEncoding;
   /** Maximum buffer size for output (default: 10MB) */
   maxBuffer?: number;
+  /** Abort command execution and close its WebSocket. */
+  signal?: AbortSignal;
+  /** Abort command execution after this many milliseconds. */
+  timeoutMs?: number;
 }
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -72,8 +72,8 @@ export interface ExecOptions extends SpawnOptions {
   maxBuffer?: number;
   /** Abort command execution and close its WebSocket. */
   signal?: AbortSignal;
-  /** Abort command execution after this many milliseconds. */
-  timeoutMs?: number;
+  /** Abort command execution after this many milliseconds. 0 disables the timeout. */
+  timeout?: number;
 }
 
 /**

--- a/src/websocket.ts
+++ b/src/websocket.ts
@@ -23,6 +23,7 @@ export class WSCommand extends EventEmitter {
   private tty: boolean;
   private started: boolean = false;
   private done: boolean = false;
+  private closeRequested: boolean = false;
   private pingInterval: ReturnType<typeof setInterval> | null = null;
   private pongTimeout: ReturnType<typeof setTimeout> | null = null;
   private lastPongTime: number = 0;
@@ -68,6 +69,11 @@ export class WSCommand extends EventEmitter {
         this.ws.binaryType = 'arraybuffer';
 
         this.ws.addEventListener('open', async () => {
+          if (this.closeRequested) {
+            this.ws?.close(1000, '');
+            return;
+          }
+
           // When attaching to an existing session, wait for session_info to determine TTY mode
           if (this.isAttach) {
             try {
@@ -349,6 +355,7 @@ export class WSCommand extends EventEmitter {
    */
   close(): void {
     this.stopKeepalive();
+    this.closeRequested = true;
     if (this.ws && this.ws.readyState === WebSocket.OPEN) {
       this.ws.close(1000, '');
     }
@@ -369,4 +376,3 @@ export class WSCommand extends EventEmitter {
     });
   }
 }
-

--- a/src/websocket.ts
+++ b/src/websocket.ts
@@ -356,7 +356,16 @@ export class WSCommand extends EventEmitter {
   close(): void {
     this.stopKeepalive();
     this.closeRequested = true;
-    if (this.ws && this.ws.readyState === WebSocket.OPEN) {
+
+    if (!this.done) {
+      this.done = true;
+      this.emit('exit', this.exitCode);
+    }
+
+    if (this.ws && (
+      this.ws.readyState === WebSocket.CONNECTING ||
+      this.ws.readyState === WebSocket.OPEN
+    )) {
       this.ws.close(1000, '');
     }
   }


### PR DESCRIPTION
## Summary

- close an exec WebSocket whenever `execFile()` resolves or rejects, including connection errors and output-buffer failures
- add opt-in `signal` and `timeoutMs` cancellation for commands that never deliver an exit frame
- handle cancellation while the WebSocket is still connecting
- document the new execution limits

## User impact

Long-running applications can recover the native socket and TLS resources from failed or abandoned executions instead of accumulating open connections until the process runs out of memory.

## Validation

- `npm test` (72 passed, 1 integration suite skipped because `SPRITES_TEST_TOKEN` is not set)
- regression coverage verifies cleanup after a WebSocket error, output-buffer overflow, timeout, and abort during connection setup

## Versioning and deployment

This is a backwards-compatible patch fix. The repository's publish workflow owns the package version, so this PR does not independently change `package.json`; no service deployment is required.

Fixes #18.
