### PR TITLE
Add client signal attribution

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,6 +239,17 @@ try {
 }
 ```
 
+### Usage attribution
+
+The SDK adds privacy-safe client signals to Sprites API requests and WebSocket
+handshakes. These include coarse process context in `Fly-Client-*` headers and
+the SDK version in `User-Agent`; they do not include command arguments or
+environment values.
+
+Set `SPRITES_CLIENT_SIGNALS=0` to disable client-signal detection and headers.
+The SDK version remains in `User-Agent`. The values `off`, `false`, `no`, and
+`disabled` are also accepted.
+
 ### Sprite Management
 
 ```typescript

--- a/README.md
+++ b/README.md
@@ -250,6 +250,9 @@ Set `SPRITES_CLIENT_SIGNALS=0` to disable client-signal detection and headers.
 The SDK version remains in `User-Agent`. The values `off`, `false`, `no`, and
 `disabled` are also accepted.
 
+Signals are detected once per process, on the first API call, so set this
+before the first request. Changing it afterwards has no effect.
+
 ### Sprite Management
 
 ```typescript

--- a/package-lock.json
+++ b/package-lock.json
@@ -59,7 +59,7 @@
     },
     "vendor/client-signals": {
       "name": "@fly/client-signals",
-      "version": "0.4.3",
+      "version": "0.4.4",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=20"

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,11 +8,11 @@
       "name": "@fly/sprites",
       "version": "0.1.0-dev",
       "bundleDependencies": [
-        "@superfly/client-signals"
+        "@fly/client-signals"
       ],
       "license": "MIT",
       "dependencies": {
-        "@superfly/client-signals": "file:vendor/client-signals"
+        "@fly/client-signals": "file:vendor/client-signals"
       },
       "devDependencies": {
         "@types/node": "^24.0.0",
@@ -22,7 +22,7 @@
         "node": ">=24.0.0"
       }
     },
-    "node_modules/@superfly/client-signals": {
+    "node_modules/@fly/client-signals": {
       "resolved": "vendor/client-signals",
       "link": true
     },
@@ -58,7 +58,7 @@
       "license": "MIT"
     },
     "vendor/client-signals": {
-      "name": "@superfly/client-signals",
+      "name": "@fly/client-signals",
       "version": "0.4.3",
       "license": "Apache-2.0",
       "engines": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,13 @@
     "": {
       "name": "@fly/sprites",
       "version": "0.1.0-dev",
+      "bundleDependencies": [
+        "@superfly/client-signals"
+      ],
       "license": "MIT",
+      "dependencies": {
+        "@superfly/client-signals": "file:vendor/client-signals"
+      },
       "devDependencies": {
         "@types/node": "^24.0.0",
         "typescript": "^5.6.0"
@@ -15,6 +21,10 @@
       "engines": {
         "node": ">=24.0.0"
       }
+    },
+    "node_modules/@superfly/client-signals": {
+      "resolved": "vendor/client-signals",
+      "link": true
     },
     "node_modules/@types/node": {
       "version": "24.6.1",
@@ -46,6 +56,14 @@
       "integrity": "sha512-Ov2Rr9Sx+fRgagJ5AX0qvItZG/JKKoBRAVITs1zk7IqZGTJUwgUr7qoYBpWwakpWilTZFM98rG/AFRocu10iIQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "vendor/client-signals": {
+      "name": "@superfly/client-signals",
+      "version": "0.4.3",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=20"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -48,7 +48,8 @@
     "dist/**/*.d.ts.map",
     "!dist/**/*.test.*",
     "README.md",
-    "LICENSE"
+    "LICENSE",
+    "vendor/client-signals"
   ],
   "dependencies": {
     "@fly/client-signals": "file:vendor/client-signals"

--- a/package.json
+++ b/package.json
@@ -51,10 +51,10 @@
     "LICENSE"
   ],
   "dependencies": {
-    "@superfly/client-signals": "file:vendor/client-signals"
+    "@fly/client-signals": "file:vendor/client-signals"
   },
   "bundledDependencies": [
-    "@superfly/client-signals"
+    "@fly/client-signals"
   ],
   "devDependencies": {
     "@types/node": "^24.0.0",

--- a/package.json
+++ b/package.json
@@ -50,6 +50,12 @@
     "README.md",
     "LICENSE"
   ],
+  "dependencies": {
+    "@superfly/client-signals": "file:vendor/client-signals"
+  },
+  "bundledDependencies": [
+    "@superfly/client-signals"
+  ],
   "devDependencies": {
     "@types/node": "^24.0.0",
     "typescript": "^5.6.0"

--- a/src/attribution.test.ts
+++ b/src/attribution.test.ts
@@ -1,0 +1,159 @@
+/**
+ * Every authenticated transport in the SDK must carry client-signal
+ * attribution. These tests exercise one call per module so a new call site
+ * that skips authHeaders() fails here instead of shipping unattributed.
+ */
+
+import assert from 'node:assert/strict';
+import { afterEach, describe, it } from 'node:test';
+import { SpritesClient } from './client.js';
+import { ControlConnection } from './control.js';
+import { SpriteCommand } from './exec.js';
+import { ProxySession } from './proxy.js';
+import { PortWatcher } from './watch.js';
+
+const originalFetch = globalThis.fetch;
+const originalWebSocket = globalThis.WebSocket;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  globalThis.WebSocket = originalWebSocket;
+});
+
+const TOKEN = 'attribution-token';
+
+function client(): SpritesClient {
+  return new SpritesClient(TOKEN, { baseURL: 'https://example.test' });
+}
+
+/** Assert a captured header bag carries signals, a user agent, and auth. */
+function assertAttributed(headers: Record<string, string> | undefined, label: string): void {
+  assert.ok(headers, `${label}: no headers captured`);
+  assert.match(headers['User-Agent'], /^sprites-js\//, `${label}: User-Agent`);
+  assert.match(headers['Fly-Client-Interactive'], /^(true|false)$/, `${label}: interactive`);
+  assert.match(headers['Fly-Client-Parent'], /^(node|python|shell|other)$/, `${label}: parent`);
+  assert.equal(headers.Authorization, `Bearer ${TOKEN}`, `${label}: authorization`);
+}
+
+/** Capture headers from every fetch, answering with an empty JSON object. */
+function captureFetchHeaders(): Array<Record<string, string>> {
+  const captured: Array<Record<string, string>> = [];
+  globalThis.fetch = (async (_input: string | URL | Request, init?: RequestInit) => {
+    captured.push((init?.headers ?? {}) as Record<string, string>);
+    return new Response('{}', {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    });
+  }) as typeof fetch;
+  return captured;
+}
+
+/**
+ * Capture headers from every WebSocket handshake, then open on the next tick.
+ * `replyWith` is delivered as a text frame so callers that block on a server
+ * reply can finish instead of leaving their timeout pending.
+ */
+function captureSocketHeaders(replyWith?: string): Array<Record<string, string>> {
+  const captured: Array<Record<string, string>> = [];
+  class FakeWebSocket extends EventTarget {
+    static readonly CONNECTING = 0;
+    readonly CONNECTING = 0;
+    binaryType = 'blob';
+    readyState = 0;
+
+    constructor(_url: string, options?: { headers?: Record<string, string> }) {
+      super();
+      captured.push(options?.headers ?? {});
+      queueMicrotask(() => {
+        this.readyState = 1;
+        this.dispatchEvent(new Event('open'));
+      });
+    }
+
+    send(): void {
+      if (replyWith === undefined) return;
+      // Deferred a full turn so the caller has registered its message handler.
+      setTimeout(() => {
+        this.dispatchEvent(new MessageEvent('message', { data: replyWith }));
+      }, 0);
+    }
+
+    close(): void {}
+  }
+  globalThis.WebSocket = FakeWebSocket as unknown as typeof WebSocket;
+  return captured;
+}
+
+/** REST paths, one per module that builds its own request headers. */
+const restCases: Array<[string, (sprite: any, api: SpritesClient) => Promise<unknown>]> = [
+  ['client.listSprites', (_sprite, api) => api.listSprites()],
+  ['sprite.listSessions', sprite => sprite.listSessions()],
+  ['sprite.listCheckpoints', sprite => sprite.listCheckpoints()],
+  ['services.listServices', sprite => sprite.listServices()],
+  ['services.restartService', sprite => sprite.restartService('web')],
+  ['policy.getNetworkPolicy', sprite => sprite.getNetworkPolicy()],
+  ['policy.getPrivilegesPolicy', sprite => sprite.getPrivilegesPolicy()],
+  ['filesystem.readFile', sprite => sprite.filesystem().readFile('/etc/hostname')],
+  ['exec.execFileHTTP', sprite => sprite.execFileHTTP('echo', ['hi'])],
+  ['exec.killSession', sprite => sprite.killSession('session-1')],
+];
+
+describe('client signal attribution', () => {
+  for (const [label, call] of restCases) {
+    it(`attributes ${label}`, async () => {
+      const captured = captureFetchHeaders();
+      const api = client();
+      // Response handling is out of scope here; only the request headers matter.
+      await call(api.sprite('my-sprite'), api).catch(() => {});
+      assertAttributed(captured[0], label);
+    });
+  }
+
+  it('attributes command WebSocket handshakes', async () => {
+    const captured = captureSocketHeaders();
+    const command = new SpriteCommand(client().sprite('my-sprite'), 'echo', ['hello']);
+    try {
+      await command.start();
+      assertAttributed(captured[0], 'exec.SpriteCommand');
+    } finally {
+      // start() opens a keepalive interval that would hold the test process open.
+      (command as any).wsCmd.close();
+    }
+  });
+
+  it('attributes port watch WebSocket handshakes', async () => {
+    const captured = captureSocketHeaders();
+    await new PortWatcher(client(), 'my-sprite').connect();
+    assertAttributed(captured[0], 'watch.PortWatcher');
+  });
+
+  it('attributes control WebSocket handshakes', async () => {
+    const captured = captureSocketHeaders();
+    await new ControlConnection(client().sprite('my-sprite')).connect();
+    assertAttributed(captured[0], 'control.ControlConnection');
+  });
+
+  it('attributes proxy WebSocket handshakes', async () => {
+    // A refused response unwinds handleConnection right after the handshake.
+    const captured = captureSocketHeaders(
+      JSON.stringify({ status: 'refused', target: 'localhost:5678' })
+    );
+    const session = new ProxySession(client(), 'my-sprite', {
+      localPort: 1234,
+      remotePort: 5678,
+    });
+    const socket = { destroy() {}, on() {}, end() {}, write() {} };
+    await (session as any).handleConnection(socket).catch(() => {});
+    assertAttributed(captured[0], 'proxy.ProxySession');
+  });
+
+  it('leaves the credential exchange unattributed', async () => {
+    const captured = captureFetchHeaders();
+    await SpritesClient.createToken('macaroon', 'my-org').catch(() => {});
+    const headers = captured[0] ?? {};
+    assert.equal(
+      Object.keys(headers).some(name => name.startsWith('Fly-Client-')),
+      false
+    );
+  });
+});

--- a/src/client-signals.test.ts
+++ b/src/client-signals.test.ts
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
 import { afterEach, describe, it } from 'node:test';
 import { resetCachedForTest } from '@fly/client-signals';
-import { resetSignalHeadersForTest, signalHeaders } from './client-signals.js';
+import { authHeaders, resetSignalHeadersForTest, signalHeaders } from './client-signals.js';
 
 const originalSignalsSetting = process.env.SPRITES_CLIENT_SIGNALS;
 const originalInvokedBy = process.env.FLY_INVOKED_BY;
@@ -60,4 +60,29 @@ describe('client signals', () => {
       assert.match(headers['User-Agent'], /^sprites-js\/[^ ]+$/);
     });
   }
+});
+
+describe('authHeaders', () => {
+  it('combines signals, bearer auth, and request-specific extras', () => {
+    delete process.env.SPRITES_CLIENT_SIGNALS;
+    resetCachedForTest();
+    resetSignalHeadersForTest();
+
+    const headers = authHeaders('secret', { 'Content-Type': 'application/json' });
+    assert.equal(headers.Authorization, 'Bearer secret');
+    assert.equal(headers['Content-Type'], 'application/json');
+    assert.match(headers['User-Agent'], /^sprites-js\//);
+    assert.match(headers['Fly-Client-Interactive'], /^(true|false)$/);
+    assert.match(headers['Fly-Client-Parent'], /^(node|python|shell|other)$/);
+  });
+
+  it('still authenticates when signals are disabled', () => {
+    process.env.SPRITES_CLIENT_SIGNALS = '0';
+    resetCachedForTest();
+    resetSignalHeadersForTest();
+
+    const headers = authHeaders('secret');
+    assert.equal(headers.Authorization, 'Bearer secret');
+    assert.deepEqual(Object.keys(headers).sort(), ['Authorization', 'User-Agent']);
+  });
 });

--- a/src/client-signals.test.ts
+++ b/src/client-signals.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import { afterEach, describe, it } from 'node:test';
-import { resetCachedForTest } from '@superfly/client-signals';
+import { resetCachedForTest } from '@fly/client-signals';
 import { resetSignalHeadersForTest, signalHeaders } from './client-signals.js';
 
 const originalSignalsSetting = process.env.SPRITES_CLIENT_SIGNALS;

--- a/src/client-signals.test.ts
+++ b/src/client-signals.test.ts
@@ -1,0 +1,63 @@
+import assert from 'node:assert/strict';
+import { afterEach, describe, it } from 'node:test';
+import { resetCachedForTest } from '@superfly/client-signals';
+import { resetSignalHeadersForTest, signalHeaders } from './client-signals.js';
+
+const originalSignalsSetting = process.env.SPRITES_CLIENT_SIGNALS;
+const originalInvokedBy = process.env.FLY_INVOKED_BY;
+
+afterEach(() => {
+  if (originalSignalsSetting === undefined) {
+    delete process.env.SPRITES_CLIENT_SIGNALS;
+  } else {
+    process.env.SPRITES_CLIENT_SIGNALS = originalSignalsSetting;
+  }
+  if (originalInvokedBy === undefined) {
+    delete process.env.FLY_INVOKED_BY;
+  } else {
+    process.env.FLY_INVOKED_BY = originalInvokedBy;
+  }
+  resetCachedForTest();
+  resetSignalHeadersForTest();
+});
+
+describe('client signals', () => {
+  it('adds Fly attribution headers and a signals-aware user agent', () => {
+    delete process.env.SPRITES_CLIENT_SIGNALS;
+    process.env.FLY_INVOKED_BY = 'sdk-test';
+    resetCachedForTest();
+    resetSignalHeadersForTest();
+
+    const headers = signalHeaders();
+    assert.equal(headers['Fly-Client-Agent'], 'sdk-test');
+    assert.equal(headers['Fly-Client-Agent-Source'], 'env:FLY_INVOKED_BY');
+    assert.match(headers['Fly-Client-Interactive'], /^(true|false)$/);
+    assert.match(headers['Fly-Client-Parent'], /^(node|python|shell|other)$/);
+    assert.match(headers['User-Agent'], /^sprites-js\/[^ ]+ \(.+agent=sdk-test\)$/);
+  });
+
+  it('computes signals once and returns a fresh header object', () => {
+    process.env.FLY_INVOKED_BY = 'first-agent';
+    resetCachedForTest();
+    resetSignalHeadersForTest();
+
+    const first = signalHeaders();
+    process.env.FLY_INVOKED_BY = 'second-agent';
+    first['Fly-Client-Agent'] = 'mutated';
+
+    assert.equal(signalHeaders()['Fly-Client-Agent'], 'first-agent');
+  });
+
+  for (const setting of ['0', 'off', 'false', 'no', 'disabled']) {
+    it(`supports the ${setting} opt-out value`, () => {
+      process.env.SPRITES_CLIENT_SIGNALS = setting;
+      process.env.FLY_INVOKED_BY = 'should-not-appear';
+      resetCachedForTest();
+      resetSignalHeadersForTest();
+
+      const headers = signalHeaders();
+      assert.deepEqual(Object.keys(headers), ['User-Agent']);
+      assert.match(headers['User-Agent'], /^sprites-js\/[^ ]+$/);
+    });
+  }
+});

--- a/src/client-signals.test.ts
+++ b/src/client-signals.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import { afterEach, describe, it } from 'node:test';
-import { resetCachedForTest } from '@fly/client-signals';
+import { KNOWN_MARKERS, resetCachedForTest } from '@fly/client-signals';
 import { authHeaders, resetSignalHeadersForTest, signalHeaders } from './client-signals.js';
 
 const originalSignalsSetting = process.env.SPRITES_CLIENT_SIGNALS;
@@ -22,6 +22,18 @@ afterEach(() => {
 });
 
 describe('client signals', () => {
+  it('includes the reviewed Grok Build marker', () => {
+    assert.deepEqual(
+      KNOWN_MARKERS.find(marker => marker.agent === 'grok'),
+      {
+        agent: 'grok',
+        env: 'GROK_AGENT',
+        kind: 'exactValue',
+        values: ['1'],
+      }
+    );
+  });
+
   it('adds Fly attribution headers and a signals-aware user agent', () => {
     delete process.env.SPRITES_CLIENT_SIGNALS;
     process.env.FLY_INVOKED_BY = 'sdk-test';

--- a/src/client-signals.ts
+++ b/src/client-signals.ts
@@ -3,7 +3,7 @@ import {
   detectOnce,
   headersFor,
   userAgentSuffix,
-} from '@superfly/client-signals';
+} from '@fly/client-signals';
 
 const DISABLE_VALUES = new Set(['0', 'off', 'false', 'no', 'disabled']);
 const require = createRequire(import.meta.url);

--- a/src/client-signals.ts
+++ b/src/client-signals.ts
@@ -1,0 +1,40 @@
+import { createRequire } from 'node:module';
+import {
+  detectOnce,
+  headersFor,
+  userAgentSuffix,
+} from '@superfly/client-signals';
+
+const DISABLE_VALUES = new Set(['0', 'off', 'false', 'no', 'disabled']);
+const require = createRequire(import.meta.url);
+const { version } = require('../package.json') as { version: string };
+
+let cachedHeaders: Readonly<Record<string, string>> | undefined;
+
+function disabled(): boolean {
+  return DISABLE_VALUES.has(
+    (process.env.SPRITES_CLIENT_SIGNALS ?? '').trim().toLowerCase()
+  );
+}
+
+function computeHeaders(): Readonly<Record<string, string>> {
+  const userAgent = `sprites-js/${version}`;
+  if (disabled()) return { 'User-Agent': userAgent };
+
+  const signals = detectOnce();
+  return {
+    ...headersFor(signals),
+    'User-Agent': `${userAgent} ${userAgentSuffix(signals)}`,
+  };
+}
+
+/** Return a fresh copy of process-wide client-signal headers. */
+export function signalHeaders(): Record<string, string> {
+  cachedHeaders ??= computeHeaders();
+  return { ...cachedHeaders };
+}
+
+/** @internal */
+export function resetSignalHeadersForTest(): void {
+  cachedHeaders = undefined;
+}

--- a/src/client-signals.ts
+++ b/src/client-signals.ts
@@ -6,6 +6,8 @@ import {
 } from '@fly/client-signals';
 
 const DISABLE_VALUES = new Set(['0', 'off', 'false', 'no', 'disabled']);
+// package.json sits outside rootDir, so it cannot be imported. Bundlers that
+// drop package.json from their output will need to shim this read.
 const require = createRequire(import.meta.url);
 const { version } = require('../package.json') as { version: string };
 
@@ -28,10 +30,33 @@ function computeHeaders(): Readonly<Record<string, string>> {
   };
 }
 
-/** Return a fresh copy of process-wide client-signal headers. */
+/**
+ * Return a fresh copy of process-wide client-signal headers.
+ *
+ * Signals and the SPRITES_CLIENT_SIGNALS opt-out are read once, on the first
+ * call, and reused for the life of the process.
+ */
 export function signalHeaders(): Record<string, string> {
   cachedHeaders ??= computeHeaders();
   return { ...cachedHeaders };
+}
+
+/**
+ * Build the headers for an authenticated Sprites request: client signals,
+ * bearer authorization, and any request-specific extras.
+ *
+ * Every authenticated REST call and WebSocket handshake in the SDK goes
+ * through this so attribution cannot be missed at a new call site.
+ */
+export function authHeaders(
+  token: string,
+  extra?: Record<string, string>
+): Record<string, string> {
+  return {
+    ...signalHeaders(),
+    Authorization: `Bearer ${token}`,
+    ...extra,
+  };
 }
 
 /** @internal */

--- a/src/client.test.ts
+++ b/src/client.test.ts
@@ -101,6 +101,11 @@ describe('SpritesClient public interface', () => {
       wait_for_capacity: true,
       runtime: 'dev',
     });
+    const headers = calls[0].init?.headers as Record<string, string>;
+    assert.match(headers['User-Agent'], /^sprites-js\//);
+    assert.match(headers['Fly-Client-Interactive'], /^(true|false)$/);
+    assert.match(headers['Fly-Client-Parent'], /^(node|python|shell|other)$/);
+    assert.equal(headers.Authorization, 'Bearer token');
     assert.equal(sprite.config?.ramMB, 4096);
     assert.equal(sprite.organizationName, 'test-org');
     assert.equal(sprite.urlSettings?.privateAccess, 'admins');
@@ -206,6 +211,8 @@ describe('SpritesClient public interface', () => {
     assert.deepEqual(JSON.parse(calls[0].init?.body as string), {
       description: 'Sprite SDK Token', invite_code: 'invite',
     });
+    const headers = calls[0].init?.headers as Record<string, string>;
+    assert.equal(Object.keys(headers).some(name => name.startsWith('Fly-Client-')), false);
   });
 
   it('surfaces structured API and network errors', async () => {

--- a/src/client.ts
+++ b/src/client.ts
@@ -3,7 +3,7 @@
  */
 
 import { Sprite } from './sprite.js';
-import { signalHeaders } from './client-signals.js';
+import { authHeaders } from './client-signals.js';
 import { parseAPIError } from './types.js';
 import type {
   ClientOptions,
@@ -142,10 +142,7 @@ export class SpritesClient {
 
     const response = await this.fetch(`${this.baseURL}/v1/sprites`, {
       method: 'POST',
-      headers: {
-        'Authorization': `Bearer ${this.token}`,
-        'Content-Type': 'application/json',
-      },
+      headers: authHeaders(this.token, { 'Content-Type': 'application/json' }),
       body: JSON.stringify(toAPIRequest(request)),
       signal: AbortSignal.timeout(120000), // 2 minute timeout for creation
     });
@@ -168,9 +165,7 @@ export class SpritesClient {
   async getSprite(name: string): Promise<Sprite> {
     const response = await this.fetch(`${this.baseURL}/v1/sprites/${encodeURIComponent(name)}`, {
       method: 'GET',
-      headers: {
-        'Authorization': `Bearer ${this.token}`,
-      },
+      headers: authHeaders(this.token),
       signal: AbortSignal.timeout(this.timeout),
     });
 
@@ -200,9 +195,7 @@ export class SpritesClient {
     const url = `${this.baseURL}/v1/sprites${query ? `?${query}` : ''}`;
     const response = await this.fetch(url, {
       method: 'GET',
-      headers: {
-        'Authorization': `Bearer ${this.token}`,
-      },
+      headers: authHeaders(this.token),
       signal: AbortSignal.timeout(this.timeout),
     });
 
@@ -236,10 +229,7 @@ export class SpritesClient {
     const query = params.toString();
     const response = await this.fetch(`${this.baseURL}/v1/sprites${query ? `?${query}` : ''}`, {
       method: 'GET',
-      headers: {
-        'Authorization': `Bearer ${this.token}`,
-        'Accept': 'application/x-ndjson',
-      },
+      headers: authHeaders(this.token, { 'Accept': 'application/x-ndjson' }),
     });
     if (!response.ok) {
       const body = await response.text();
@@ -280,9 +270,7 @@ export class SpritesClient {
   async deleteSprite(name: string): Promise<void> {
     const response = await this.fetch(`${this.baseURL}/v1/sprites/${encodeURIComponent(name)}`, {
       method: 'DELETE',
-      headers: {
-        'Authorization': `Bearer ${this.token}`,
-      },
+      headers: authHeaders(this.token),
       signal: AbortSignal.timeout(this.timeout),
     });
 
@@ -301,9 +289,7 @@ export class SpritesClient {
   async upgradeSprite(name: string): Promise<void> {
     const response = await this.fetch(`${this.baseURL}/v1/sprites/${encodeURIComponent(name)}/upgrade`, {
       method: 'POST',
-      headers: {
-        'Authorization': `Bearer ${this.token}`,
-      },
+      headers: authHeaders(this.token),
       signal: AbortSignal.timeout(60000),
     });
 
@@ -322,7 +308,7 @@ export class SpritesClient {
       `${this.baseURL}/v1/sprites/${encodeURIComponent(name)}/restart`,
       {
         method: 'POST',
-        headers: { 'Authorization': `Bearer ${this.token}` },
+        headers: authHeaders(this.token),
         signal: AbortSignal.timeout(60000),
       }
     );
@@ -340,7 +326,7 @@ export class SpritesClient {
       `${this.baseURL}/v1/sprites/${encodeURIComponent(name)}/check`,
       {
         method: 'GET',
-        headers: { 'Authorization': `Bearer ${this.token}` },
+        headers: authHeaders(this.token),
         signal: AbortSignal.timeout(this.timeout),
       }
     );
@@ -372,10 +358,7 @@ export class SpritesClient {
 
     const response = await this.fetch(`${this.baseURL}/v1/sprites/${encodeURIComponent(name)}`, {
       method: 'PUT',
-      headers: {
-        'Authorization': `Bearer ${this.token}`,
-        'Content-Type': 'application/json',
-      },
+      headers: authHeaders(this.token, { 'Content-Type': 'application/json' }),
       body: JSON.stringify(toAPIRequest(options)),
       signal: AbortSignal.timeout(this.timeout),
     });
@@ -444,13 +427,7 @@ export class SpritesClient {
    */
   private async fetch(url: string, init?: RequestInit): Promise<Response> {
     try {
-      return await fetch(url, {
-        ...init,
-        headers: {
-          ...signalHeaders(),
-          ...((init?.headers ?? {}) as Record<string, string>),
-        },
-      });
+      return await fetch(url, init);
     } catch (error) {
       if (error instanceof Error) {
         throw new Error(`Network error: ${error.message}`);

--- a/src/client.ts
+++ b/src/client.ts
@@ -3,6 +3,7 @@
  */
 
 import { Sprite } from './sprite.js';
+import { signalHeaders } from './client-signals.js';
 import { parseAPIError } from './types.js';
 import type {
   ClientOptions,
@@ -410,6 +411,8 @@ export class SpritesClient {
       body.invite_code = inviteCode;
     }
 
+    // Keep attribution off the credential-minting request. Client signals are
+    // attached only after a caller has a Sprites access token.
     const response = await fetch(url, {
       method: 'POST',
       headers: {
@@ -441,7 +444,13 @@ export class SpritesClient {
    */
   private async fetch(url: string, init?: RequestInit): Promise<Response> {
     try {
-      return await fetch(url, init);
+      return await fetch(url, {
+        ...init,
+        headers: {
+          ...signalHeaders(),
+          ...((init?.headers ?? {}) as Record<string, string>),
+        },
+      });
     } catch (error) {
       if (error instanceof Error) {
         throw new Error(`Network error: ${error.message}`);

--- a/src/control.ts
+++ b/src/control.ts
@@ -3,6 +3,7 @@
  */
 
 import { EventEmitter } from 'node:events';
+import { signalHeaders } from './client-signals.js';
 import type { Sprite } from './sprite.js';
 import { StreamID } from './types.js';
 
@@ -253,6 +254,7 @@ export class ControlConnection extends EventEmitter {
       try {
         this.ws = new WebSocket(url, {
           headers: {
+            ...signalHeaders(),
             'Authorization': `Bearer ${this.sprite.client.token}`,
           },
         });

--- a/src/control.ts
+++ b/src/control.ts
@@ -3,7 +3,7 @@
  */
 
 import { EventEmitter } from 'node:events';
-import { signalHeaders } from './client-signals.js';
+import { authHeaders } from './client-signals.js';
 import type { Sprite } from './sprite.js';
 import { StreamID } from './types.js';
 
@@ -253,10 +253,7 @@ export class ControlConnection extends EventEmitter {
     return new Promise((resolve, reject) => {
       try {
         this.ws = new WebSocket(url, {
-          headers: {
-            ...signalHeaders(),
-            'Authorization': `Bearer ${this.sprite.client.token}`,
-          },
+          headers: authHeaders(this.sprite.client.token),
         });
 
         this.ws.binaryType = 'arraybuffer';

--- a/src/exec.test.ts
+++ b/src/exec.test.ts
@@ -5,6 +5,7 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert';
 import { SpritesClient } from './client.js';
+import { SpriteCommand } from './exec.js';
 import {
   ExecError,
   APIError,
@@ -14,6 +15,17 @@ import {
 } from './types.js';
 
 describe('WebSocket URL Building', () => {
+  it('adds client signals to command WebSocket handshakes', () => {
+    const client = new SpritesClient('test-token', { baseURL: 'https://example.test' });
+    const command = new SpriteCommand(client.sprite('my-sprite'), 'echo', ['hello']);
+    const headers = (command as any).wsCmd.headers as Record<string, string>;
+
+    assert.match(headers['User-Agent'], /^sprites-js\//);
+    assert.match(headers['Fly-Client-Interactive'], /^(true|false)$/);
+    assert.match(headers['Fly-Client-Parent'], /^(node|python|shell|other)$/);
+    assert.equal(headers.Authorization, 'Bearer test-token');
+  });
+
   it('should build correct WebSocket URL for basic command', () => {
     const client = new SpritesClient('test-token', { baseURL: 'http://localhost:8080' });
     const sprite = client.sprite('my-sprite');
@@ -364,4 +376,3 @@ describe('parseAPIError', () => {
     assert.strictEqual(err.isConcurrentLimitExceeded(), true);
   });
 });
-

--- a/src/exec.ts
+++ b/src/exec.ts
@@ -4,7 +4,7 @@
 
 import { EventEmitter } from 'node:events';
 import { Readable, Writable, PassThrough } from 'node:stream';
-import { signalHeaders } from './client-signals.js';
+import { authHeaders } from './client-signals.js';
 import { WSCommand } from './websocket.js';
 import type { Sprite } from './sprite.js';
 import type { SpawnOptions, ExecOptions, ExecResult } from './types.js';
@@ -58,10 +58,7 @@ export class SpriteCommand extends EventEmitter {
     // Create WebSocket command
     this.wsCmd = new WSCommand(
       url,
-      {
-        ...signalHeaders(),
-        'Authorization': `Bearer ${this.sprite.client.token}`,
-      },
+      authHeaders(this.sprite.client.token),
       options.tty || false
     );
 
@@ -393,11 +390,9 @@ export async function execFileHTTP(
 
   const response = await fetch(url, {
     method: 'POST',
-    headers: {
-      ...signalHeaders(),
-      'Authorization': `Bearer ${sprite.client.token}`,
+    headers: authHeaders(sprite.client.token, {
       'Content-Type': 'application/octet-stream',
-    },
+    }),
     body: options.input === undefined ? undefined :
       typeof options.input === 'string' ? Buffer.from(options.input) : options.input,
     signal: requestSignal,
@@ -476,7 +471,7 @@ export async function killSession(
   if (timeout) url.searchParams.set('timeout', timeout);
   const response = await fetch(url, {
     method: 'POST',
-    headers: { ...signalHeaders(), 'Authorization': `Bearer ${sprite.client.token}` },
+    headers: authHeaders(sprite.client.token),
   });
   if (!response.ok) {
     const body = await response.text();

--- a/src/exec.ts
+++ b/src/exec.ts
@@ -4,6 +4,7 @@
 
 import { EventEmitter } from 'node:events';
 import { Readable, Writable, PassThrough } from 'node:stream';
+import { signalHeaders } from './client-signals.js';
 import { WSCommand } from './websocket.js';
 import type { Sprite } from './sprite.js';
 import type { SpawnOptions, ExecOptions, ExecResult } from './types.js';
@@ -58,6 +59,7 @@ export class SpriteCommand extends EventEmitter {
     this.wsCmd = new WSCommand(
       url,
       {
+        ...signalHeaders(),
         'Authorization': `Bearer ${this.sprite.client.token}`,
       },
       options.tty || false
@@ -392,6 +394,7 @@ export async function execFileHTTP(
   const response = await fetch(url, {
     method: 'POST',
     headers: {
+      ...signalHeaders(),
       'Authorization': `Bearer ${sprite.client.token}`,
       'Content-Type': 'application/octet-stream',
     },
@@ -473,7 +476,7 @@ export async function killSession(
   if (timeout) url.searchParams.set('timeout', timeout);
   const response = await fetch(url, {
     method: 'POST',
-    headers: { 'Authorization': `Bearer ${sprite.client.token}` },
+    headers: { ...signalHeaders(), 'Authorization': `Bearer ${sprite.client.token}` },
   });
   if (!response.ok) {
     const body = await response.text();

--- a/src/filesystem.ts
+++ b/src/filesystem.ts
@@ -4,6 +4,7 @@
  */
 
 import { SpritesClient } from './client.js';
+import { signalHeaders } from './client-signals.js';
 import { FilesystemError } from './types.js';
 import { FilesystemWatcher } from './watch.js';
 import type {
@@ -164,6 +165,7 @@ export class SpriteFilesystem {
    */
   private getHeaders(): Record<string, string> {
     return {
+      ...signalHeaders(),
       'Authorization': `Bearer ${this.client.token}`,
     };
   }

--- a/src/filesystem.ts
+++ b/src/filesystem.ts
@@ -4,7 +4,7 @@
  */
 
 import { SpritesClient } from './client.js';
-import { signalHeaders } from './client-signals.js';
+import { authHeaders } from './client-signals.js';
 import { FilesystemError } from './types.js';
 import { FilesystemWatcher } from './watch.js';
 import type {
@@ -164,10 +164,7 @@ export class SpriteFilesystem {
    * Get authorization headers
    */
   private getHeaders(): Record<string, string> {
-    return {
-      ...signalHeaders(),
-      'Authorization': `Bearer ${this.client.token}`,
-    };
+    return authHeaders(this.client.token);
   }
 
   /**

--- a/src/policy.ts
+++ b/src/policy.ts
@@ -2,6 +2,7 @@
  * Network policy API handlers
  */
 
+import { signalHeaders } from './client-signals.js';
 import type { NetworkPolicy, PrivilegesPolicy, ResourcesPolicy } from './types.js';
 
 interface ClientInfo {
@@ -21,6 +22,7 @@ export async function getNetworkPolicy(
     {
       method: 'GET',
       headers: {
+        ...signalHeaders(),
         Authorization: `Bearer ${client.token}`,
       },
       signal: AbortSignal.timeout(30000),
@@ -50,6 +52,7 @@ export async function updateNetworkPolicy(
     {
       method: 'POST',
       headers: {
+        ...signalHeaders(),
         Authorization: `Bearer ${client.token}`,
         'Content-Type': 'application/json',
       },
@@ -83,6 +86,7 @@ async function policyRequest<T>(
     {
       method,
       headers: {
+        ...signalHeaders(),
         Authorization: `Bearer ${client.token}`,
         ...(body !== undefined && { 'Content-Type': 'application/json' }),
       },

--- a/src/policy.ts
+++ b/src/policy.ts
@@ -2,7 +2,7 @@
  * Network policy API handlers
  */
 
-import { signalHeaders } from './client-signals.js';
+import { authHeaders } from './client-signals.js';
 import type { NetworkPolicy, PrivilegesPolicy, ResourcesPolicy } from './types.js';
 
 interface ClientInfo {
@@ -21,10 +21,7 @@ export async function getNetworkPolicy(
     `${client.baseURL}/v1/sprites/${encodeURIComponent(spriteName)}/policy/network`,
     {
       method: 'GET',
-      headers: {
-        ...signalHeaders(),
-        Authorization: `Bearer ${client.token}`,
-      },
+      headers: authHeaders(client.token),
       signal: AbortSignal.timeout(30000),
     }
   );
@@ -51,11 +48,7 @@ export async function updateNetworkPolicy(
     `${client.baseURL}/v1/sprites/${encodeURIComponent(spriteName)}/policy/network`,
     {
       method: 'POST',
-      headers: {
-        ...signalHeaders(),
-        Authorization: `Bearer ${client.token}`,
-        'Content-Type': 'application/json',
-      },
+      headers: authHeaders(client.token, { 'Content-Type': 'application/json' }),
       body: JSON.stringify(policy),
       signal: AbortSignal.timeout(30000),
     }
@@ -85,11 +78,9 @@ async function policyRequest<T>(
     `${client.baseURL}/v1/sprites/${encodeURIComponent(spriteName)}/policy/${kind}`,
     {
       method,
-      headers: {
-        ...signalHeaders(),
-        Authorization: `Bearer ${client.token}`,
+      headers: authHeaders(client.token, {
         ...(body !== undefined && { 'Content-Type': 'application/json' }),
-      },
+      }),
       ...(body !== undefined && { body: JSON.stringify(body) }),
       signal: AbortSignal.timeout(30000),
     }

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -4,7 +4,7 @@
 
 import { EventEmitter } from 'node:events';
 import { createServer, Socket, Server } from 'node:net';
-import { signalHeaders } from './client-signals.js';
+import { authHeaders } from './client-signals.js';
 import type { PortMapping, ProxyInitMessage, ProxyResponseMessage } from './types.js';
 
 /**
@@ -65,10 +65,7 @@ export class ProxySession extends EventEmitter {
 
     try {
       const ws = new WebSocket(wsURL, {
-        headers: {
-          ...signalHeaders(),
-          'Authorization': `Bearer ${this.client.token}`,
-        },
+        headers: authHeaders(this.client.token),
       });
 
       ws.binaryType = 'arraybuffer';

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -4,6 +4,7 @@
 
 import { EventEmitter } from 'node:events';
 import { createServer, Socket, Server } from 'node:net';
+import { signalHeaders } from './client-signals.js';
 import type { PortMapping, ProxyInitMessage, ProxyResponseMessage } from './types.js';
 
 /**
@@ -65,6 +66,7 @@ export class ProxySession extends EventEmitter {
     try {
       const ws = new WebSocket(wsURL, {
         headers: {
+          ...signalHeaders(),
           'Authorization': `Bearer ${this.client.token}`,
         },
       });

--- a/src/services.ts
+++ b/src/services.ts
@@ -2,7 +2,7 @@
  * Services API handlers
  */
 
-import { signalHeaders } from './client-signals.js';
+import { authHeaders } from './client-signals.js';
 import type {
   ServiceWithState,
   ServiceRequest,
@@ -184,10 +184,7 @@ export async function listServices(
     servicesURL(client, spriteName),
     {
       method: 'GET',
-      headers: {
-        ...signalHeaders(),
-        Authorization: `Bearer ${client.token}`,
-      },
+      headers: authHeaders(client.token),
       signal: AbortSignal.timeout(30000),
     }
   );
@@ -216,10 +213,7 @@ export async function getService(
     servicesURL(client, spriteName, `/${encodeURIComponent(serviceName)}`),
     {
       method: 'GET',
-      headers: {
-        ...signalHeaders(),
-        Authorization: `Bearer ${client.token}`,
-      },
+      headers: authHeaders(client.token),
       signal: AbortSignal.timeout(30000),
     }
   );
@@ -257,11 +251,7 @@ export async function createService(
 
   const response = await fetch(url, {
     method: 'PUT',
-    headers: {
-      ...signalHeaders(),
-      Authorization: `Bearer ${client.token}`,
-      'Content-Type': 'application/json',
-    },
+    headers: authHeaders(client.token, { 'Content-Type': 'application/json' }),
     body: JSON.stringify(serviceRequestToAPI(config)),
   });
 
@@ -292,10 +282,7 @@ export async function deleteService(
     servicesURL(client, spriteName, `/${encodeURIComponent(serviceName)}`),
     {
       method: 'DELETE',
-      headers: {
-        ...signalHeaders(),
-        Authorization: `Bearer ${client.token}`,
-      },
+      headers: authHeaders(client.token),
       signal: AbortSignal.timeout(30000),
     }
   );
@@ -335,10 +322,7 @@ export async function startService(
 
   const response = await fetch(url, {
     method: 'POST',
-    headers: {
-      ...signalHeaders(),
-      Authorization: `Bearer ${client.token}`,
-    },
+    headers: authHeaders(client.token),
   });
 
   if (response.status === 404) {
@@ -373,10 +357,7 @@ export async function stopService(
 
   const response = await fetch(url, {
     method: 'POST',
-    headers: {
-      ...signalHeaders(),
-      Authorization: `Bearer ${client.token}`,
-    },
+    headers: authHeaders(client.token),
   });
 
   if (response.status === 404) {
@@ -410,7 +391,7 @@ export async function restartService(
   if (duration) url.searchParams.set('duration', duration);
   const response = await fetch(url, {
     method: 'POST',
-    headers: { ...signalHeaders(), Authorization: `Bearer ${client.token}` },
+    headers: authHeaders(client.token),
   });
   if (!response.ok) {
     const body = await response.text();
@@ -431,7 +412,7 @@ export async function getServiceLogs(
   if (options.duration) url.searchParams.set('duration', options.duration);
   const response = await fetch(url, {
     method: 'GET',
-    headers: { ...signalHeaders(), Authorization: `Bearer ${client.token}` },
+    headers: authHeaders(client.token),
   });
   if (!response.ok) {
     const body = await response.text();
@@ -453,11 +434,7 @@ export async function signalService(
     servicesURL(client, spriteName, '/signal'),
     {
       method: 'POST',
-      headers: {
-        ...signalHeaders(),
-        Authorization: `Bearer ${client.token}`,
-        'Content-Type': 'application/json',
-      },
+      headers: authHeaders(client.token, { 'Content-Type': 'application/json' }),
       body: JSON.stringify({ name: serviceName, signal }),
       signal: AbortSignal.timeout(30000),
     }

--- a/src/services.ts
+++ b/src/services.ts
@@ -2,6 +2,7 @@
  * Services API handlers
  */
 
+import { signalHeaders } from './client-signals.js';
 import type {
   ServiceWithState,
   ServiceRequest,
@@ -184,6 +185,7 @@ export async function listServices(
     {
       method: 'GET',
       headers: {
+        ...signalHeaders(),
         Authorization: `Bearer ${client.token}`,
       },
       signal: AbortSignal.timeout(30000),
@@ -215,6 +217,7 @@ export async function getService(
     {
       method: 'GET',
       headers: {
+        ...signalHeaders(),
         Authorization: `Bearer ${client.token}`,
       },
       signal: AbortSignal.timeout(30000),
@@ -255,6 +258,7 @@ export async function createService(
   const response = await fetch(url, {
     method: 'PUT',
     headers: {
+      ...signalHeaders(),
       Authorization: `Bearer ${client.token}`,
       'Content-Type': 'application/json',
     },
@@ -289,6 +293,7 @@ export async function deleteService(
     {
       method: 'DELETE',
       headers: {
+        ...signalHeaders(),
         Authorization: `Bearer ${client.token}`,
       },
       signal: AbortSignal.timeout(30000),
@@ -331,6 +336,7 @@ export async function startService(
   const response = await fetch(url, {
     method: 'POST',
     headers: {
+      ...signalHeaders(),
       Authorization: `Bearer ${client.token}`,
     },
   });
@@ -368,6 +374,7 @@ export async function stopService(
   const response = await fetch(url, {
     method: 'POST',
     headers: {
+      ...signalHeaders(),
       Authorization: `Bearer ${client.token}`,
     },
   });
@@ -403,7 +410,7 @@ export async function restartService(
   if (duration) url.searchParams.set('duration', duration);
   const response = await fetch(url, {
     method: 'POST',
-    headers: { Authorization: `Bearer ${client.token}` },
+    headers: { ...signalHeaders(), Authorization: `Bearer ${client.token}` },
   });
   if (!response.ok) {
     const body = await response.text();
@@ -424,7 +431,7 @@ export async function getServiceLogs(
   if (options.duration) url.searchParams.set('duration', options.duration);
   const response = await fetch(url, {
     method: 'GET',
-    headers: { Authorization: `Bearer ${client.token}` },
+    headers: { ...signalHeaders(), Authorization: `Bearer ${client.token}` },
   });
   if (!response.ok) {
     const body = await response.text();
@@ -447,6 +454,7 @@ export async function signalService(
     {
       method: 'POST',
       headers: {
+        ...signalHeaders(),
         Authorization: `Bearer ${client.token}`,
         'Content-Type': 'application/json',
       },

--- a/src/sprite.ts
+++ b/src/sprite.ts
@@ -3,7 +3,7 @@
  */
 
 import { SpritesClient } from './client.js';
-import { signalHeaders } from './client-signals.js';
+import { authHeaders } from './client-signals.js';
 import { SpriteCommand, SessionKillStream, spawn, exec, execFile, execFileHTTP, killSession } from './exec.js';
 import { CheckpointStream, RestoreStream } from './checkpoint.js';
 import { ProxySession, proxyPort, proxyPorts } from './proxy.js';
@@ -137,10 +137,7 @@ export class Sprite {
   async listSessions(): Promise<Session[]> {
     const response = await fetch(`${this.baseURL()}/exec`, {
       method: 'GET',
-      headers: {
-        ...signalHeaders(),
-        'Authorization': `Bearer ${this.client.token}`,
-      },
+      headers: authHeaders(this.client.token),
       signal: AbortSignal.timeout(30000),
     });
 
@@ -227,11 +224,7 @@ export class Sprite {
     if (comment) body.comment = comment;
     const response = await fetch(`${this.baseURL()}/checkpoint`, {
       method: 'POST',
-      headers: {
-        ...signalHeaders(),
-        'Authorization': `Bearer ${this.client.token}`,
-        'Content-Type': 'application/json',
-      },
+      headers: authHeaders(this.client.token, { 'Content-Type': 'application/json' }),
       body: JSON.stringify(body),
       // No timeout: checkpoint streams can be long-running
     });
@@ -253,10 +246,7 @@ export class Sprite {
     }
     const response = await fetch(url, {
       method: 'GET',
-      headers: {
-        ...signalHeaders(),
-        'Authorization': `Bearer ${this.client.token}`,
-      },
+      headers: authHeaders(this.client.token),
       signal: AbortSignal.timeout(30000),
     });
     if (!response.ok) {
@@ -281,10 +271,7 @@ export class Sprite {
   async getCheckpoint(id: string): Promise<Checkpoint> {
     const response = await fetch(`${this.baseURL()}/checkpoints/${encodeURIComponent(id)}`, {
       method: 'GET',
-      headers: {
-        ...signalHeaders(),
-        'Authorization': `Bearer ${this.client.token}`,
-      },
+      headers: authHeaders(this.client.token),
       signal: AbortSignal.timeout(30000),
     });
     if (response.status === 404) {
@@ -313,10 +300,7 @@ export class Sprite {
   async restoreCheckpoint(id: string): Promise<RestoreStream> {
     const response = await fetch(`${this.baseURL()}/checkpoints/${encodeURIComponent(id)}/restore`, {
       method: 'POST',
-      headers: {
-        ...signalHeaders(),
-        'Authorization': `Bearer ${this.client.token}`,
-      },
+      headers: authHeaders(this.client.token),
       // No timeout: restore streams can be long-running
     });
     if (!response.ok) {

--- a/src/sprite.ts
+++ b/src/sprite.ts
@@ -3,6 +3,7 @@
  */
 
 import { SpritesClient } from './client.js';
+import { signalHeaders } from './client-signals.js';
 import { SpriteCommand, SessionKillStream, spawn, exec, execFile, execFileHTTP, killSession } from './exec.js';
 import { CheckpointStream, RestoreStream } from './checkpoint.js';
 import { ProxySession, proxyPort, proxyPorts } from './proxy.js';
@@ -137,6 +138,7 @@ export class Sprite {
     const response = await fetch(`${this.baseURL()}/exec`, {
       method: 'GET',
       headers: {
+        ...signalHeaders(),
         'Authorization': `Bearer ${this.client.token}`,
       },
       signal: AbortSignal.timeout(30000),
@@ -226,6 +228,7 @@ export class Sprite {
     const response = await fetch(`${this.baseURL()}/checkpoint`, {
       method: 'POST',
       headers: {
+        ...signalHeaders(),
         'Authorization': `Bearer ${this.client.token}`,
         'Content-Type': 'application/json',
       },
@@ -251,6 +254,7 @@ export class Sprite {
     const response = await fetch(url, {
       method: 'GET',
       headers: {
+        ...signalHeaders(),
         'Authorization': `Bearer ${this.client.token}`,
       },
       signal: AbortSignal.timeout(30000),
@@ -278,6 +282,7 @@ export class Sprite {
     const response = await fetch(`${this.baseURL()}/checkpoints/${encodeURIComponent(id)}`, {
       method: 'GET',
       headers: {
+        ...signalHeaders(),
         'Authorization': `Bearer ${this.client.token}`,
       },
       signal: AbortSignal.timeout(30000),
@@ -309,6 +314,7 @@ export class Sprite {
     const response = await fetch(`${this.baseURL()}/checkpoints/${encodeURIComponent(id)}/restore`, {
       method: 'POST',
       headers: {
+        ...signalHeaders(),
         'Authorization': `Bearer ${this.client.token}`,
       },
       // No timeout: restore streams can be long-running

--- a/src/watch.ts
+++ b/src/watch.ts
@@ -1,5 +1,5 @@
 import { EventEmitter } from 'node:events';
-import { signalHeaders } from './client-signals.js';
+import { authHeaders } from './client-signals.js';
 import type { SpritesClient } from './client.js';
 import type { FilesystemWatchEvent, PortWatchEvent } from './types.js';
 
@@ -17,9 +17,7 @@ class WebSocketJSONStream<T> extends EventEmitter implements AsyncIterable<T> {
   protected async connectURL(url: string, token: string, initialMessage?: unknown): Promise<void> {
     if (this.ws) throw new Error('Watcher already connected');
     await new Promise<void>((resolve, reject) => {
-      const ws = new WebSocket(url, {
-        headers: { ...signalHeaders(), 'Authorization': `Bearer ${token}` },
-      });
+      const ws = new WebSocket(url, { headers: authHeaders(token) });
       this.ws = ws;
       let connected = false;
       ws.addEventListener('open', () => {

--- a/src/watch.ts
+++ b/src/watch.ts
@@ -1,4 +1,5 @@
 import { EventEmitter } from 'node:events';
+import { signalHeaders } from './client-signals.js';
 import type { SpritesClient } from './client.js';
 import type { FilesystemWatchEvent, PortWatchEvent } from './types.js';
 
@@ -16,7 +17,9 @@ class WebSocketJSONStream<T> extends EventEmitter implements AsyncIterable<T> {
   protected async connectURL(url: string, token: string, initialMessage?: unknown): Promise<void> {
     if (this.ws) throw new Error('Watcher already connected');
     await new Promise<void>((resolve, reject) => {
-      const ws = new WebSocket(url, { headers: { 'Authorization': `Bearer ${token}` } });
+      const ws = new WebSocket(url, {
+        headers: { ...signalHeaders(), 'Authorization': `Bearer ${token}` },
+      });
       this.ws = ws;
       let connected = false;
       ws.addEventListener('open', () => {

--- a/vendor/client-signals/LICENSE
+++ b/vendor/client-signals/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/vendor/client-signals/README.md
+++ b/vendor/client-signals/README.md
@@ -4,7 +4,7 @@ This is the JavaScript package from
 [superfly/client-signals](https://github.com/superfly/client-signals) at
 release `v0.4.3`.
 
-It is bundled with `@fly/sprites` because `@superfly/client-signals` is not yet
+It is bundled with `@fly/sprites` because `@fly/client-signals` is not yet
 published to npm. The runtime source is unmodified. This vendored package adds
 TypeScript declarations and corrects the package license metadata to match the
 upstream Apache-2.0 repository license. Replace the file dependency with the

--- a/vendor/client-signals/README.md
+++ b/vendor/client-signals/README.md
@@ -1,0 +1,11 @@
+# Vendored client-signals
+
+This is the JavaScript package from
+[superfly/client-signals](https://github.com/superfly/client-signals) at
+release `v0.4.3`.
+
+It is bundled with `@fly/sprites` because `@superfly/client-signals` is not yet
+published to npm. The runtime source is unmodified. This vendored package adds
+TypeScript declarations and corrects the package license metadata to match the
+upstream Apache-2.0 repository license. Replace the file dependency with the
+published npm package once one is available.

--- a/vendor/client-signals/README.md
+++ b/vendor/client-signals/README.md
@@ -7,5 +7,13 @@ release `v0.4.3`.
 It is bundled with `@fly/sprites` because `@fly/client-signals` is not yet
 published to npm. The runtime source is unmodified. This vendored package adds
 TypeScript declarations and corrects the package license metadata to match the
-upstream Apache-2.0 repository license. Replace the file dependency with the
-published npm package once one is available.
+upstream Apache-2.0 repository license.
+
+`@fly/sprites` ships this directory two ways: npm resolves the dependency from
+the bundled `node_modules` copy, and the `files` entry keeps `vendor/` in the
+tarball so the `file:vendor/client-signals` specifier still resolves under
+package managers that handle `bundledDependencies` differently.
+
+Once `@fly/client-signals` is on npm, delete this directory and replace the
+file dependency, the `bundledDependencies` entry, and the `files` entry with a
+normal registry version range.

--- a/vendor/client-signals/README.md
+++ b/vendor/client-signals/README.md
@@ -1,19 +1,20 @@
 # Vendored client-signals
 
-This is the JavaScript package from
-[superfly/client-signals](https://github.com/superfly/client-signals) at
-release `v0.4.3`.
+This is the JavaScript implementation from
+[superfly/client-signals](https://github.com/superfly/client-signals) release
+[`v0.4.4`](https://github.com/superfly/client-signals/releases/tag/v0.4.4).
 
-It is bundled with `@fly/sprites` because `@fly/client-signals` is not yet
-published to npm. The runtime source is unmodified. This vendored package adds
-TypeScript declarations and corrects the package license metadata to match the
-upstream Apache-2.0 repository license.
+The JavaScript implementation is not published to npm. Vendoring it inside
+`@fly/sprites` is the supported distribution model. The runtime source and
+TypeScript declarations are unmodified; the package metadata is adapted for
+bundling and carries the upstream Apache-2.0 license.
 
 `@fly/sprites` ships this directory two ways: npm resolves the dependency from
 the bundled `node_modules` copy, and the `files` entry keeps `vendor/` in the
 tarball so the `file:vendor/client-signals` specifier still resolves under
 package managers that handle `bundledDependencies` differently.
 
-Once `@fly/client-signals` is on npm, delete this directory and replace the
-file dependency, the `bundledDependencies` entry, and the `files` entry with a
-normal registry version range.
+To update the snapshot, copy the runtime and declarations from a reviewed
+upstream release, update the release link above, and keep the local dependency,
+`bundledDependencies`, and `files` entries in sync. Then run the full test
+suite and verify that the packed `@fly/sprites` tarball installs offline.

--- a/vendor/client-signals/package.json
+++ b/vendor/client-signals/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fly/client-signals",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "description": "Privacy-safe client signals for CLI HTTP traffic.",
   "type": "module",
   "main": "./src/index.js",

--- a/vendor/client-signals/package.json
+++ b/vendor/client-signals/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@superfly/client-signals",
+  "version": "0.4.3",
+  "description": "Privacy-safe client signals for CLI HTTP traffic.",
+  "type": "module",
+  "main": "./src/index.js",
+  "types": "./src/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./src/index.d.ts",
+      "default": "./src/index.js"
+    }
+  },
+  "files": [
+    "src",
+    "README.md",
+    "LICENSE"
+  ],
+  "engines": {
+    "node": ">=20"
+  },
+  "license": "Apache-2.0"
+}

--- a/vendor/client-signals/package.json
+++ b/vendor/client-signals/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@superfly/client-signals",
+  "name": "@fly/client-signals",
   "version": "0.4.3",
   "description": "Privacy-safe client signals for CLI HTTP traffic.",
   "type": "module",

--- a/vendor/client-signals/src/index.d.ts
+++ b/vendor/client-signals/src/index.d.ts
@@ -1,4 +1,5 @@
 export type ParentBucket = "node" | "python" | "shell" | "other";
+export type Operator = "ci" | "agent" | "interactive" | "unknown";
 
 export interface Signals {
   interactive: boolean;
@@ -8,10 +9,39 @@ export interface Signals {
   ci: boolean;
 }
 
+export interface AgentMarker {
+  agent: string;
+  env: string;
+  kind: "presence" | "exactValue";
+  values?: readonly string[];
+}
+
+export interface SetHeaderTarget {
+  setHeader(name: string, value: string): unknown;
+}
+
+export interface SetTarget {
+  set(name: string, value: string): unknown;
+}
+
+export const DEFAULT_HEADER_PREFIX: "Fly";
+export const KNOWN_MARKERS: readonly AgentMarker[];
+
+export function detect(): Signals;
 export function detectOnce(): Signals;
 export function resetCachedForTest(): void;
 export function headersFor(
   signals: Signals,
   prefix?: string,
 ): Record<string, string>;
+export function applyHeaders<T extends SetHeaderTarget | SetTarget | Record<string, string>>(
+  target: T,
+  signals: Signals,
+  prefix?: string,
+): T;
 export function userAgentSuffix(signals: Signals): string;
+export function operator(signals: Signals): Operator;
+export function sanitizeInvokedBy(value: unknown): [string | undefined, boolean];
+export function classifyParentName(raw: unknown): ParentBucket;
+export function loadJSONFixture(path: URL): unknown;
+export function isInteractiveFileForTest(path: string | URL): boolean;

--- a/vendor/client-signals/src/index.d.ts
+++ b/vendor/client-signals/src/index.d.ts
@@ -1,0 +1,17 @@
+export type ParentBucket = "node" | "python" | "shell" | "other";
+
+export interface Signals {
+  interactive: boolean;
+  parent: ParentBucket;
+  agent: string;
+  agentSource: string;
+  ci: boolean;
+}
+
+export function detectOnce(): Signals;
+export function resetCachedForTest(): void;
+export function headersFor(
+  signals: Signals,
+  prefix?: string,
+): Record<string, string>;
+export function userAgentSuffix(signals: Signals): string;

--- a/vendor/client-signals/src/index.js
+++ b/vendor/client-signals/src/index.js
@@ -1,0 +1,206 @@
+import { readFileSync, statSync } from "node:fs";
+import { basename } from "node:path";
+import { fileURLToPath } from "node:url";
+
+export const DEFAULT_HEADER_PREFIX = "Fly";
+
+const MAX_INVOKED_BY_LEN = 64;
+const INVOKED_BY_PATTERN = /^[a-z0-9][a-z0-9-]{0,63}$/;
+
+export const KNOWN_MARKERS = [
+  { agent: "claude-code", env: "CLAUDECODE", kind: "exactValue", values: ["1"] },
+  { agent: "claude-code", env: "CLAUDE_CODE_ENTRYPOINT", kind: "presence" },
+  { agent: "pi", env: "PI_CODING_AGENT", kind: "exactValue", values: ["true"] },
+  { agent: "openclaw", env: "OPENCLAW_SHELL", kind: "exactValue", values: ["exec"] },
+  { agent: "openclaw", env: "OPENCLAW_CLI", kind: "exactValue", values: ["1"] },
+  { agent: "goose", env: "GOOSE_TERMINAL", kind: "exactValue", values: ["1"] },
+  { agent: "hermes", env: "HERMES_SESSION_ID", kind: "presence" },
+  { agent: "codex", env: "CODEX_SANDBOX", kind: "presence" },
+  { agent: "codex", env: "CODEX_THREAD_ID", kind: "presence" },
+  { agent: "cursor", env: "CURSOR_TRACE_ID", kind: "presence" },
+  { agent: "cursor", env: "CURSOR_AGENT", kind: "presence" },
+  { agent: "gemini-cli", env: "GEMINI_CLI", kind: "presence" },
+  { agent: "kiro", env: "TERM_PROGRAM", kind: "exactValue", values: ["kiro"] },
+  { agent: "antigravity", env: "ANTIGRAVITY_AGENT", kind: "presence" },
+  { agent: "augment", env: "AUGMENT_AGENT", kind: "presence" },
+  { agent: "replit", env: "REPL_ID", kind: "presence" },
+  { agent: "opencode", env: "OPENCODE", kind: "presence" },
+  { agent: "opencode", env: "OPENCODE_CALLER", kind: "presence" },
+  { agent: "opencode", env: "OPENCODE_CLIENT", kind: "presence" },
+  { agent: "copilot", env: "COPILOT_MODEL", kind: "presence" },
+  { agent: "copilot", env: "COPILOT_ALLOW_ALL", kind: "presence" },
+  { agent: "kilo-code", env: "KILO_PLATFORM", kind: "exactValue", values: ["vscode"] },
+];
+
+let cachedSignals;
+
+export function detect() {
+  const [agent, agentSource] = detectAgent();
+  return {
+    interactive: isInteractive(),
+    parent: parentBucket(),
+    agent,
+    agentSource,
+    ci: isCI(),
+  };
+}
+
+export function detectOnce() {
+  if (cachedSignals === undefined) {
+    cachedSignals = detect();
+  }
+  return cachedSignals;
+}
+
+export function resetCachedForTest() {
+  cachedSignals = undefined;
+}
+
+export function headersFor(signals, prefix = DEFAULT_HEADER_PREFIX) {
+  const headers = {
+    [`${prefix}-Client-Interactive`]: String(Boolean(signals.interactive)),
+    [`${prefix}-Client-Parent`]: signals.parent,
+  };
+  if (signals.agent) {
+    headers[`${prefix}-Client-Agent`] = signals.agent;
+    headers[`${prefix}-Client-Agent-Source`] = signals.agentSource;
+  }
+  if (signals.ci) {
+    headers[`${prefix}-Client-CI`] = "true";
+  }
+  return headers;
+}
+
+export function applyHeaders(target, signals, prefix = DEFAULT_HEADER_PREFIX) {
+  for (const [name, value] of Object.entries(headersFor(signals, prefix))) {
+    if (typeof target.set === "function") {
+      target.set(name, value);
+    } else if (typeof target.setHeader === "function") {
+      target.setHeader(name, value);
+    } else {
+      target[name] = value;
+    }
+  }
+  return target;
+}
+
+export function userAgentSuffix(signals) {
+  let suffix = `interactive=${Boolean(signals.interactive)}; parent=${signals.parent}`;
+  if (signals.agent) {
+    suffix += `; agent=${signals.agent}`;
+  }
+  return `(${suffix})`;
+}
+
+// operator returns one process-operator classification. Precedence is
+// ci > agent > interactive > unknown.
+export function operator(signals) {
+  if (signals.ci) {
+    return "ci";
+  }
+  if (signals.agent) {
+    return "agent";
+  }
+  if (signals.interactive) {
+    return "interactive";
+  }
+  return "unknown";
+}
+
+export function sanitizeInvokedBy(value) {
+  const sanitized = String(value).trim().toLowerCase();
+  if (sanitized.length === 0 || sanitized.length > MAX_INVOKED_BY_LEN) {
+    return [undefined, false];
+  }
+  if (!INVOKED_BY_PATTERN.test(sanitized)) {
+    return [undefined, false];
+  }
+  return [sanitized, true];
+}
+
+export function classifyParentName(raw) {
+  let name = basename(String(raw).toLowerCase());
+  if (name.endsWith(".exe")) {
+    name = name.slice(0, -4);
+  }
+
+  if (name === "node") {
+    return "node";
+  }
+  if (name === "python" || name === "python3" || name === "python2") {
+    return "python";
+  }
+  if (["bash", "zsh", "fish", "sh", "dash", "ksh", "tcsh", "csh", "cmd", "powershell", "pwsh"].includes(name)) {
+    return "shell";
+  }
+  return "other";
+}
+
+function detectAgent() {
+  if (hasEnv("FLY_INVOKED_BY")) {
+    const [agent, ok] = sanitizeInvokedBy(process.env.FLY_INVOKED_BY);
+    if (ok) {
+      return [agent, "env:FLY_INVOKED_BY"];
+    }
+  }
+
+  for (const marker of KNOWN_MARKERS) {
+    if (!hasEnv(marker.env)) {
+      continue;
+    }
+    if (marker.kind === "presence") {
+      return [marker.agent, `env:${marker.env}`];
+    }
+    if (marker.values.includes(process.env[marker.env])) {
+      return [marker.agent, `env:${marker.env}`];
+    }
+  }
+
+  if (hasEnv("AGENT")) {
+    const [agent, ok] = sanitizeInvokedBy(process.env.AGENT);
+    if (ok) {
+      return [agent, "env:AGENT"];
+    }
+  }
+
+  return ["", ""];
+}
+
+function isInteractive() {
+  return Boolean(process.stdout?.isTTY);
+}
+
+function isCI() {
+  return hasEnv("CI") || hasEnv("GITHUB_ACTIONS");
+}
+
+function parentBucket() {
+  return classifyParentName(lookupParentName(process.ppid));
+}
+
+function lookupParentName(ppid) {
+  if (process.platform === "linux") {
+    try {
+      return readFileSync(`/proc/${ppid}/comm`, "utf8").trim();
+    } catch {
+      return "";
+    }
+  }
+  return "";
+}
+
+function hasEnv(name) {
+  return Object.prototype.hasOwnProperty.call(process.env, name);
+}
+
+export function loadJSONFixture(path) {
+  return JSON.parse(readFileSync(fileURLToPath(path), "utf8"));
+}
+
+export function isInteractiveFileForTest(path) {
+  try {
+    return statSync(path).isCharacterDevice();
+  } catch {
+    return false;
+  }
+}

--- a/vendor/client-signals/src/index.js
+++ b/vendor/client-signals/src/index.js
@@ -30,6 +30,11 @@ export const KNOWN_MARKERS = [
   { agent: "copilot", env: "COPILOT_MODEL", kind: "presence" },
   { agent: "copilot", env: "COPILOT_ALLOW_ALL", kind: "presence" },
   { agent: "kilo-code", env: "KILO_PLATFORM", kind: "exactValue", values: ["vscode"] },
+  // GROK_AGENT is dual-use: Grok Build sets it to "1" in the environment of the
+  // subprocesses its tools spawn, but it is also a documented user-facing
+  // setting whose value is a custom agent name or definition path. Matching the
+  // exact value "1" keeps this to the tool-set form.
+  { agent: "grok", env: "GROK_AGENT", kind: "exactValue", values: ["1"] },
 ];
 
 let cachedSignals;


### PR DESCRIPTION
## Summary

- compute privacy-safe client signals once per process
- attach Fly client headers and an SDK user agent to every Sprites REST and WebSocket path
- support `SPRITES_CLIENT_SIGNALS` opt-out values
- bundle the JavaScript implementation from `client-signals` v0.4.4, including Grok detection
- keep credential-minting requests unattributed
- add REST, WebSocket, caching, opt-out, and vendored-marker coverage

## User impact

The Fly backend can attribute SDK traffic to interactive users, automation, and supported agents without collecting command arguments or environment values. Users can opt out of attribution while retaining the basic SDK user agent. `@fly/sprites` remains installable without a separately published npm package for `client-signals`.

## Testing

- npm test: 94 passed
- TypeScript build passed
- packed tarball contains the bundled v0.4.4 runtime
- packed tarball installed and imported successfully with npm in offline mode
- git diff --check passed

## Deployment

No backend deployment or `client-signals` npm publication is required. The v0.4.4 JavaScript implementation is vendored and bundled into the next `@fly/sprites` npm release.
