### PR TITLE
Fail test CLI on checkpoint stream errors

### DIFF
--- a/test-node-cli/package.json
+++ b/test-node-cli/package.json
@@ -12,6 +12,7 @@
   "scripts": {
     "build": "tsc && chmod +x dist/index.js",
     "watch": "tsc --watch",
+    "test": "npm run build && node --test dist/**/*.test.js",
     "clean": "rm -rf dist"
   },
   "devDependencies": {

--- a/test-node-cli/src/checkpoint-events.test.ts
+++ b/test-node-cli/src/checkpoint-events.test.ts
@@ -1,0 +1,37 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { consumeCheckpointEvents } from './checkpoint-events.js';
+
+async function* events(...items: Array<{ type: string; error?: string }>) {
+  yield* items;
+}
+
+describe('consumeCheckpointEvents', () => {
+  it('prints successful streams', async () => {
+    const written: string[] = [];
+    await consumeCheckpointEvents(
+      events({ type: 'info' }, { type: 'complete' }),
+      event => written.push(event.type),
+    );
+    assert.deepEqual(written, ['info', 'complete']);
+  });
+
+  it('rejects a terminal error after printing it', async () => {
+    const written: string[] = [];
+    await assert.rejects(
+      consumeCheckpointEvents(
+        events({ type: 'info' }, { type: 'error', error: 'rename failed' }),
+        event => written.push(event.type),
+      ),
+      /rename failed/,
+    );
+    assert.deepEqual(written, ['info', 'error']);
+  });
+
+  it('does not treat a mid-stream error as terminal', async () => {
+    await consumeCheckpointEvents(
+      events({ type: 'error', error: 'advisory' }, { type: 'complete' }),
+      () => {},
+    );
+  });
+});

--- a/test-node-cli/src/checkpoint-events.ts
+++ b/test-node-cli/src/checkpoint-events.ts
@@ -1,0 +1,25 @@
+interface CheckpointEvent {
+  type: string;
+  error?: string;
+}
+
+/**
+ * Print every checkpoint/restore event and reject when the stream's terminal
+ * event reports an operation failure. Error events may be advisory when more
+ * events follow, so only the final event determines the operation result.
+ */
+export async function consumeCheckpointEvents(
+  stream: AsyncIterable<CheckpointEvent>,
+  write: (event: CheckpointEvent) => void = event => console.log(JSON.stringify(event)),
+): Promise<void> {
+  let lastEvent: CheckpointEvent | undefined;
+
+  for await (const event of stream) {
+    write(event);
+    lastEvent = event;
+  }
+
+  if (lastEvent?.type === 'error') {
+    throw new Error(lastEvent.error || 'Checkpoint operation failed');
+  }
+}

--- a/test-node-cli/src/index.ts
+++ b/test-node-cli/src/index.ts
@@ -8,6 +8,7 @@
 import { createWriteStream } from 'node:fs';
 import { WriteStream } from 'node:fs';
 import { SpritesClient } from '../../dist/index.js';
+import { consumeCheckpointEvents } from './checkpoint-events.js';
 
 interface CLIOptions {
   baseUrl: string;
@@ -254,9 +255,7 @@ async function handleCheckpointCommand(
           process.exit(1);
         }
         const stream = await sprite.createCheckpoint(args[1]);
-        for await (const event of stream) {
-          console.log(JSON.stringify(event));
-        }
+        await consumeCheckpointEvents(stream);
         break;
       }
       case 'restore': {
@@ -265,9 +264,7 @@ async function handleCheckpointCommand(
           process.exit(1);
         }
         const stream = await sprite.restoreCheckpoint(args[1]);
-        for await (const event of stream) {
-          console.log(JSON.stringify(event));
-        }
+        await consumeCheckpointEvents(stream);
         break;
       }
       default:


### PR DESCRIPTION
## Summary

- make checkpoint create/restore commands return nonzero when their terminal NDJSON event is an error
- preserve advisory mid-stream error events when a later completion event follows
- add focused test CLI coverage for successful, terminal-error, and advisory-error streams

## Why

The shared SDK harness uses the test CLI's exit status to decide whether checkpoint operations succeeded. The JavaScript CLI printed terminal error events but exited 0, so a real checkpoint failure was reported as success and later tests failed misleadingly.

For example, sprite-env#672 logged:

```text
{"type":"error","error":"Failed to create checkpoint: ... v2: file exists"}
--- PASS: TestCheckpointCreateAndGet
...
Expected at least 2 non-Current checkpoints, got 1
--- FAIL: TestMultipleCheckpoints
```

This makes the harness stop at the actual failed operation instead of surfacing a flaky downstream checkpoint-count assertion.

## Validation

- `npm test`
- `cd test-node-cli && npm test`
