### PR TITLE
fix(filesystem): map codeless 404 responses to ENOENT

### DIFF
--- a/src/filesystem.test.ts
+++ b/src/filesystem.test.ts
@@ -90,4 +90,37 @@ describe('SpriteFilesystem public interface', () => {
     assert.equal(await fs.exists('missing'), false);
     await fs.rm('missing', { force: true });
   });
+
+  it('maps a 404 without a structured code to ENOENT', async () => {
+    // The server currently omits the `code` field on 404 responses, e.g.
+    // reading a file that does not exist.
+    globalThis.fetch = (async () => new Response(
+      JSON.stringify({ error: 'open /app/missing.txt: no such file or directory', path: '/app/missing.txt' }),
+      { status: 404, headers: { 'content-type': 'application/json' } }
+    )) as typeof fetch;
+    const fs = new SpritesClient('token').sprite('demo').filesystem('/app');
+
+    await assert.rejects(
+      () => fs.readFile('missing.txt'),
+      (error: unknown) => error instanceof FilesystemError && error.code === 'ENOENT' && error.syscall === 'read'
+    );
+  });
+
+  it('maps a non-JSON 404 to ENOENT and other codeless failures to UNKNOWN', async () => {
+    globalThis.fetch = (async () => new Response('not found', { status: 404 })) as typeof fetch;
+    const fs = new SpritesClient('token').sprite('demo').filesystem('/app');
+    await assert.rejects(
+      () => fs.readFile('missing.txt'),
+      (error: unknown) => error instanceof FilesystemError && error.code === 'ENOENT'
+    );
+
+    globalThis.fetch = (async () => new Response(
+      JSON.stringify({ error: 'boom', path: '/app/f' }),
+      { status: 500, headers: { 'content-type': 'application/json' } }
+    )) as typeof fetch;
+    await assert.rejects(
+      () => fs.readFile('f'),
+      (error: unknown) => error instanceof FilesystemError && error.code === 'UNKNOWN'
+    );
+  });
 });

--- a/src/filesystem.ts
+++ b/src/filesystem.ts
@@ -122,6 +122,16 @@ function parseErrorCode(serverCode?: string): FilesystemErrorCode {
 }
 
 /**
+ * Map an HTTP status to a filesystem error code for responses whose body
+ * carries no structured `code` field. The server currently omits `code` on
+ * 404 responses (for example, reading a file that does not exist), which
+ * would otherwise surface as `UNKNOWN` instead of `ENOENT`.
+ */
+function statusErrorCode(status: number): FilesystemErrorCode {
+  return status === 404 ? 'ENOENT' : 'UNKNOWN';
+}
+
+/**
  * Join path segments, handling absolute paths
  */
 function joinPath(base: string, ...parts: string[]): string {
@@ -177,13 +187,15 @@ export class SpriteFilesystem {
     } catch {
       throw createError(
         `${syscall} failed with status ${response.status}`,
-        'UNKNOWN',
+        statusErrorCode(response.status),
         path,
         syscall
       );
     }
 
-    const code = parseErrorCode(errorData.code);
+    const code = errorData.code
+      ? parseErrorCode(errorData.code)
+      : statusErrorCode(response.status);
     throw createError(
       errorData.error || `${syscall} failed`,
       code,


### PR DESCRIPTION
## Problem

The filesystem API returns HTTP 404 with no structured `code` field when a client reads a file that does not exist:

```
GET /v1/sprites/<name>/fs/read?path=missing.txt
404 {"error":"open /home/sprite/missing.txt: no such file or directory","path":"..."}
```

`parseErrorCode()` sees no code and returns `UNKNOWN`. A missing file is then indistinguishable from an arbitrary failure. Downstream consumers must sniff the error text. The Python SDK already maps status 404 to `FileNotFoundError`; this PR gives the JS SDK the same behavior.

## Fix

When the response body carries no `code`, fall back to the HTTP status: 404 maps to `ENOENT` (including non-JSON 404 bodies). Other codeless failures stay `UNKNOWN`. Structured codes such as `EISDIR` are honored unchanged.

## Tests

- Unit tests cover the codeless-404 body the server actually sends, a non-JSON 404, and a codeless 500 (stays `UNKNOWN`). Full suite: 126 pass, 0 fail.
- Verified against the live API: reading a missing file now raises `FilesystemError` with `code === "ENOENT"`.

## Note

The root cause is server-side: the `/fs/read` error body omits `code` on 404 while other errors (e.g. `EISDIR`) include it. Adding `"code":"ENOENT"` to the server response would also fix Python's message-sniffing cousins; this SDK fallback is correct either way.